### PR TITLE
Bugfix: Generics not being re-expanded on enums

### DIFF
--- a/derive/src/descriptors/enum_desc.rs
+++ b/derive/src/descriptors/enum_desc.rs
@@ -134,10 +134,11 @@ impl Descriptor for EnumDescriptor {
 		let ident = &self.ident;
 		let attrs = &self.attrs;
 		let fields = self.fields.iter().map(|e| e.reexpand());
+		let generics = &self.generics;
 
 		quote! {
 			#(#attrs)*
-			#vis enum #ident {
+			#vis enum #ident #generics {
 				#(#fields,)*
 			}
 		}


### PR DESCRIPTION
Enums tagged with the revision attribute will have their generics removed. This happened because I forgot to add the generics back onto the enum when it gets re-expanded in the macro.

This PR fixes this bug.

Fixes #6.