### PR TITLE
Change deserialize error messages to use type name

### DIFF
--- a/derive/src/descriptors/enum_desc.rs
+++ b/derive/src/descriptors/enum_desc.rs
@@ -89,14 +89,15 @@ impl Descriptor for EnumDescriptor {
 			for field in &self.fields {
 				variant.extend(field.generate_deserializer(self.revision, i));
 			}
+
+			let name = &self.ident;
 			// Generate the deserializer match arm for revision `i`.
 			deserializer.extend(quote! {
 				#i => match variant {
 					#variant
 					v => return Err(revision::Error::Deserialize({
 						let res = format!(
-							"Unknown {:?} variant {}.",
-							<Self as revision::Revisioned>::type_id(),
+							concat!("Unknown '", stringify!(#name) ,"' variant {}."),
 							variant
 						);
 						res
@@ -104,6 +105,8 @@ impl Descriptor for EnumDescriptor {
 				},
 			});
 		}
+
+		let name = &self.ident;
 		// Output the token stream
 		quote! {
 			// Deserialize the data revision
@@ -115,8 +118,7 @@ impl Descriptor for EnumDescriptor {
 				#deserializer
 				v => return Err(revision::Error::Deserialize({
 					let res = format!(
-						"Unknown {:?} revision {}.",
-						<Self as revision::Revisioned>::type_id(),
+						concat!("Unknown '", stringify!(#name) ,"' variant {}."),
 						revision
 					);
 					res

--- a/derive/src/descriptors/struct_desc.rs
+++ b/derive/src/descriptors/struct_desc.rs
@@ -113,6 +113,7 @@ impl Descriptor for StructDescriptor {
 				}
 			});
 		}
+		let name = &self.ident;
 		// Output the token stream
 		quote! {
 			// Deserialize the data revision
@@ -122,8 +123,7 @@ impl Descriptor for StructDescriptor {
 				#deserializer
 				v => return Err(revision::Error::Deserialize({
 					let res = format!(
-						"Unknown {:?} revision {}.",
-						<Self as revision::Revisioned>::type_id(),
+						concat!("Unknown '", stringify!(#name) ,"' variant {}."),
 						revision
 					);
 					res


### PR DESCRIPTION
The current deserialize error messages use `TypeId` to print information about which type failed to deserialize. This is somewhat unhelpful since it is hard to find which type id belongs to which type. Furthermore this also requires the type to be `'static`. 

This PR changes the macro to instead expand the error message with the name of the type. Making the error message more helpful and removing the need for the type to be `'static`.

Will probably fix #4 