### PR TITLE
Fix a bug where tuple struct where not properly expanded

### DIFF
--- a/derive/src/fields/struct_index.rs
+++ b/derive/src/fields/struct_index.rs
@@ -123,6 +123,7 @@ impl StructIndex {
 	}
 
 	fn generate_deserializer_newfield(&self) -> (TokenStream, TokenStream, TokenStream) {
+		let index = syn::Index::from(self.index as usize);
 		// Output the token streams
 		(
 			// Field did not exist, so don't deserialize it
@@ -132,11 +133,11 @@ impl StructIndex {
 				Some(default_fn) => {
 					let default_fn = syn::Ident::new(default_fn, Span::call_site());
 					quote! {
-						Self::#default_fn(revision),
+						#index: Self::#default_fn(revision),
 					}
 				}
 				None => quote! {
-					Default::default(),
+					#index: Default::default(),
 				},
 			},
 			// No need for any field post-processing


### PR DESCRIPTION
There is a bug in the proc-macro leading to invalid syntax being produced for tuple structs.
This PR fixes this bug.

The macro would try to expand the missing tuple field 1 like the following:
```rust
struct Foo{ 0: v0, Default::default() }
```
This is not valid syntax.