### PR TITLE
Allow removal and re-adding of enum variant

### DIFF
--- a/derive/src/common.rs
+++ b/derive/src/common.rs
@@ -1,4 +1,5 @@
 /// Describes a structure and it's fields.
+#[derive(Debug)]
 pub(crate) struct GenericDescriptor<T> {
 	pub ident: syn::Ident,
 	pub vis: syn::Visibility,
@@ -10,6 +11,7 @@ pub(crate) struct GenericDescriptor<T> {
 }
 
 /// Describes a structure and it's fields.
+#[derive(Debug)]
 pub(crate) enum Kind {
 	Unit,
 	Tuple,
@@ -36,7 +38,7 @@ pub(crate) trait Exists {
 	// Get the start revision for this field
 	fn start_revision(&self) -> u16;
 	// Get the end revision for this field
-	fn end_revision(&self) -> u16;
+	fn end_revision(&self) -> Option<u16>;
 	// Get any sub revision for this field
 	fn sub_revision(&self) -> u16;
 	// Check if this field exists for this revision
@@ -44,8 +46,7 @@ pub(crate) trait Exists {
 		// All fields have an initial start revision
 		revision >= self.start_revision()
         // Not all fields have an end revision specified
-        && (0 == self.end_revision()
-                || (self.end_revision() > 0 && revision < self.end_revision()))
+        && self.end_revision().map(|x| revision < x).unwrap_or(true)
 	}
 }
 
@@ -60,8 +61,8 @@ mod tests {
 				3
 			}
 
-			fn end_revision(&self) -> u16 {
-				5
+			fn end_revision(&self) -> Option<u16> {
+				Some(5)
 			}
 
 			fn sub_revision(&self) -> u16 {

--- a/derive/src/descriptors/enum_desc.rs
+++ b/derive/src/descriptors/enum_desc.rs
@@ -1,4 +1,4 @@
-use crate::common::{Descriptor, GenericDescriptor, Kind};
+use crate::common::{Descriptor, Exists, GenericDescriptor, Kind};
 use crate::fields::enum_inner::*;
 use crate::fields::enum_struct::*;
 use crate::fields::enum_tuple::*;
@@ -65,7 +65,7 @@ impl Descriptor for EnumDescriptor {
 		// Create a new token stream
 		let mut serializer = proc_macro2::TokenStream::new();
 		// Extend the token stream for each field
-		for field in &self.fields {
+		for field in self.fields.iter().filter(|x| x.exists_at(revision)) {
 			serializer.extend(field.generate_serializer(self.revision));
 		}
 		// Output the token stream
@@ -135,7 +135,8 @@ impl Descriptor for EnumDescriptor {
 		let vis = &self.vis;
 		let ident = &self.ident;
 		let attrs = &self.attrs;
-		let fields = self.fields.iter().map(|e| e.reexpand());
+		let fields =
+			self.fields.iter().filter(|x| x.exists_at(self.revision)).map(|e| e.reexpand());
 		let generics = &self.generics;
 
 		quote! {

--- a/derive/src/fields/enum_inner.rs
+++ b/derive/src/fields/enum_inner.rs
@@ -16,7 +16,7 @@ impl Exists for EnumInner {
 			Self::EnumStruct(v) => v.start_revision(),
 		}
 	}
-	fn end_revision(&self) -> u16 {
+	fn end_revision(&self) -> Option<u16> {
 		match self {
 			Self::EnumTuple(v) => v.end_revision(),
 			Self::EnumStruct(v) => v.end_revision(),

--- a/derive/src/fields/enum_struct.rs
+++ b/derive/src/fields/enum_struct.rs
@@ -5,7 +5,6 @@ use darling::FromVariant;
 use proc_macro2::TokenStream;
 use proc_macro_error::abort;
 use quote::quote;
-use std::cmp::max;
 
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub(crate) struct EnumStruct {
@@ -20,13 +19,13 @@ impl Exists for EnumStruct {
 	fn start_revision(&self) -> u16 {
 		self.parsed.start.unwrap_or(self.revision)
 	}
-	fn end_revision(&self) -> u16 {
-		self.parsed.end.unwrap_or_default()
+	fn end_revision(&self) -> Option<u16> {
+		self.parsed.end
 	}
 	fn sub_revision(&self) -> u16 {
 		let mut revision = 1;
 		for field in self.fields.iter() {
-			revision = max(revision, max(field.start_revision(), field.end_revision()));
+			revision = revision.max(field.start_revision()).max(field.end_revision().unwrap_or(0));
 		}
 		revision
 	}

--- a/derive/src/fields/enum_struct_field.rs
+++ b/derive/src/fields/enum_struct_field.rs
@@ -15,8 +15,8 @@ impl Exists for StructField {
 	fn start_revision(&self) -> u16 {
 		self.parsed.start.unwrap_or(self.revision)
 	}
-	fn end_revision(&self) -> u16 {
-		self.parsed.end.unwrap_or_default()
+	fn end_revision(&self) -> Option<u16> {
+		self.parsed.end
 	}
 	fn sub_revision(&self) -> u16 {
 		0

--- a/derive/src/fields/enum_tuple.rs
+++ b/derive/src/fields/enum_tuple.rs
@@ -18,8 +18,8 @@ impl Exists for EnumTuple {
 	fn start_revision(&self) -> u16 {
 		self.parsed.start.unwrap_or(self.revision)
 	}
-	fn end_revision(&self) -> u16 {
-		self.parsed.end.unwrap_or_default()
+	fn end_revision(&self) -> Option<u16> {
+		self.parsed.end
 	}
 	fn sub_revision(&self) -> u16 {
 		0
@@ -87,8 +87,6 @@ impl EnumTuple {
 	}
 
 	pub fn generate_serializer(&self, current: u16) -> TokenStream {
-		// Get the name of the variant
-		let name = self.parsed.ident.to_string();
 		// Get the variant index
 		let index = self.index;
 		// Get the variant identifier
@@ -111,12 +109,7 @@ impl EnumTuple {
 		// Output the token stream
 		if self.fields.is_empty() {
 			if !self.exists_at(current) {
-				quote! {
-					Self::#ident => {
-						// TODO: remove this variant entirely using proc macro
-						panic!("The {} enum variant has been deprecated", #name);
-					},
-				}
+				panic!("tried to generate a serializer a field which was deleted.");
 			} else {
 				quote! {
 					Self::#ident => {
@@ -125,12 +118,7 @@ impl EnumTuple {
 				}
 			}
 		} else if !self.exists_at(current) {
-			quote! {
-				Self::#ident(#inner) => {
-					// TODO: remove this variant entirely using proc macro
-					panic!("The {} enum variant has been deprecated", #name);
-				},
-			}
+			panic!("tried to generate a serializer a field which was deleted.");
 		} else {
 			quote! {
 				Self::#ident(#inner) => {

--- a/derive/src/fields/struct_field.rs
+++ b/derive/src/fields/struct_field.rs
@@ -17,8 +17,8 @@ impl Exists for StructField {
 	fn start_revision(&self) -> u16 {
 		self.parsed.start.unwrap_or(self.revision)
 	}
-	fn end_revision(&self) -> u16 {
-		self.parsed.end.unwrap_or_default()
+	fn end_revision(&self) -> Option<u16> {
+		self.parsed.end
 	}
 	fn sub_revision(&self) -> u16 {
 		0

--- a/derive/src/fields/struct_index.rs
+++ b/derive/src/fields/struct_index.rs
@@ -17,8 +17,8 @@ impl Exists for StructIndex {
 	fn start_revision(&self) -> u16 {
 		self.parsed.start.unwrap_or(self.revision)
 	}
-	fn end_revision(&self) -> u16 {
-		self.parsed.end.unwrap_or_default()
+	fn end_revision(&self) -> Option<u16> {
+		self.parsed.end
 	}
 	fn sub_revision(&self) -> u16 {
 		0

--- a/derive/src/fields/struct_inner.rs
+++ b/derive/src/fields/struct_inner.rs
@@ -16,7 +16,7 @@ impl Exists for StructInner {
 			Self::StructIndex(v) => v.start_revision(),
 		}
 	}
-	fn end_revision(&self) -> u16 {
+	fn end_revision(&self) -> Option<u16> {
 		match self {
 			Self::StructField(v) => v.end_revision(),
 			Self::StructIndex(v) => v.end_revision(),

--- a/derive/src/helpers.rs
+++ b/derive/src/helpers.rs
@@ -1,5 +1,4 @@
 use crate::common::Exists;
-use std::cmp::max;
 
 /// Compute current struct revision by finding the latest field change revision.
 pub(crate) fn compute_revision<T>(fields: &[T]) -> u16
@@ -11,7 +10,7 @@ where
 		let beg = field.start_revision();
 		let end = field.end_revision();
 		let sub = field.sub_revision();
-		revision = max(revision, max(max(beg, end), sub));
+		revision = revision.max(beg).max(end.unwrap_or(0)).max(sub);
 	}
 	revision
 }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -20,6 +20,7 @@ use darling::{Error, FromMeta};
 use descriptors::enum_desc::EnumDescriptor;
 use descriptors::struct_desc::StructDescriptor;
 use proc_macro::TokenStream;
+use proc_macro_error::proc_macro_error;
 use quote::quote;
 use syn::spanned::Spanned;
 use syn::{parse_macro_input, Item};
@@ -181,6 +182,7 @@ struct Arguments {
 /// }
 /// ```
 #[proc_macro_attribute]
+#[proc_macro_error]
 pub fn revisioned(attrs: TokenStream, input: TokenStream) -> proc_macro::TokenStream {
 	// Parse the current struct input
 	let input: Item = parse_macro_input!(input as Item);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -3,8 +3,8 @@ use revision::Error;
 use revision::Revisioned;
 use std::num::Wrapping;
 
-#[derive(Debug, PartialEq)]
 #[revisioned(revision = 3)]
+#[derive(Debug, PartialEq)]
 pub enum TestEnum {
 	Zero,
 	#[revision(end = 2, convert_fn = "upgrade_one")]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -21,6 +21,10 @@ pub enum TestEnum {
 		#[revision(start = 3)]
 		d: String,
 	},
+	#[revision(end = 3, convert_fn = "upgrade_four")]
+	Four,
+	#[revision(start = 3)]
+	Four(usize),
 }
 
 impl TestEnum {
@@ -38,6 +42,10 @@ impl TestEnum {
 			_ => unreachable!(),
 		}
 		Ok(())
+	}
+
+	fn upgrade_four(_revision: u16, _: ()) -> Result<TestEnum, Error> {
+		Ok(TestEnum::Four(0))
 	}
 }
 


### PR DESCRIPTION
This PR removes enum variants which are no longer part of the current revision from the final type. Allowing the user to re-add them with a new field, or an entirely different definition altogether. 

Note that this does cause problems when the attribute is not properly ordered.
Take:
```rust
#[Derive(Debug)]
#[revisioned(revision = 2)]
enum Foo{
    #[revision(end = 2)]
    Bar,
}
```
The derive debug macro will first generate a `fmt::Debug` implementation handling the `Bar` variant before the revisioned attribute removes the variant causing a compile error. The solution is to make sure the revisioned attribute is always first.