### PR TITLE
Move Roaring bench to benches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,20 @@ jobs:
 
       - name: Test with all features
         run: cargo test --all-features --workspace
+
+      - name: Test with all features
+        run: cargo bench --all-features --workspace
+
+  bench:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Bench
+        run: cargo bench --all-features --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
         run: cargo bench --all-features --workspace
 
   bench:
-    name: Run tests
+    name: Run benchmarks
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,9 +77,6 @@ jobs:
       - name: Test with all features
         run: cargo test --all-features --workspace
 
-      - name: Test with all features
-        run: cargo bench --all-features --workspace
-
   bench:
     name: Run benchmarks
     runs-on: ubuntu-latest
@@ -92,4 +89,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Bench
-        run: cargo bench --all-features --workspace
+        run: cargo bench --all-features roaring_benchmark

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,12 @@ rust_decimal = { version = "1.31.0", optional = true }
 serde = "1.0.183"
 thiserror = "1.0.44"
 uuid = { version = "1.4.1", optional = true }
+log = "0.4.20"
 
 [dev-dependencies]
 rand = "0.8.5"
 criterion = "0.5.1"
+
+[[bench]]
+name = "roaring"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ rust_decimal = { version = "1.31.0", optional = true }
 serde = "1.0.183"
 thiserror = "1.0.44"
 uuid = { version = "1.4.1", optional = true }
-log = "0.4.20"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,4 @@ uuid = { version = "1.4.1", optional = true }
 
 [dev-dependencies]
 rand = "0.8.5"
+criterion = "0.5.1"

--- a/benches/roaring.rs
+++ b/benches/roaring.rs
@@ -1,0 +1,69 @@
+use bincode::Options;
+use criterion::{criterion_group, criterion_main, Criterion};
+use rand::random;
+use roaring::RoaringTreemap;
+use std::time::SystemTime;
+
+fn bench_roaring_serialization_time_benchmark() {
+	let mut val = RoaringTreemap::new();
+	for i in 0..1_000_000 {
+		if random() {
+			val.insert(i);
+		}
+	}
+	// COLLECTING ELAPSED TIME
+
+	//Bincode with default options is slower than direct serialization
+	let bincode_elapsed;
+	{
+		let mut mem: Vec<u8> = vec![];
+		let t = SystemTime::now();
+		bincode::serialize_into(&mut mem, &val).unwrap();
+		bincode_elapsed = t.elapsed().unwrap();
+	}
+	//Bincode with options is: As fast, but still bigger than direct serialization
+	let bincode_options_elapsed;
+	{
+		let mut mem: Vec<u8> = vec![];
+		let t = SystemTime::now();
+		bincode::options()
+			.with_no_limit()
+			.with_little_endian()
+			.with_varint_encoding()
+			.reject_trailing_bytes()
+			.serialize_into(&mut mem, &val)
+			.unwrap();
+		bincode_options_elapsed = t.elapsed().unwrap();
+	}
+	//Direct serialization  is : Faster and smaller
+	let direct_elapsed;
+	{
+		let mut mem: Vec<u8> = vec![];
+		let t = SystemTime::now();
+		val.serialize_into(&mut mem).unwrap();
+		direct_elapsed = t.elapsed().unwrap();
+	}
+
+	// ASSERTIONS
+
+	println!("Bincode::default, Bincode::options, Direct, Ratio direct/bincode::options");
+	// Direct is faster
+	println!(
+		"Elapsed - {} > {} > {} - {}",
+		bincode_elapsed.as_micros(),
+		bincode_options_elapsed.as_micros(),
+		direct_elapsed.as_micros(),
+		direct_elapsed.as_micros() as f32 / bincode_options_elapsed.as_micros() as f32
+	);
+	assert!(direct_elapsed < bincode_elapsed);
+	assert!((direct_elapsed.as_micros() as f32 / bincode_options_elapsed.as_micros() as f32) < 1.1);
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+	c.bench_function("bench_roaring_serialization_time_benchmark", |b| {
+		b.iter(bench_roaring_serialization_time_benchmark)
+	});
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/roaring.rs
+++ b/benches/roaring.rs
@@ -1,13 +1,12 @@
 use bincode::Options;
 use criterion::{criterion_group, criterion_main, Criterion};
-use log::debug;
 use rand::random;
 use roaring::RoaringTreemap;
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 
 fn bench_roaring_serialization_benchmark() {
 	let mut val = RoaringTreemap::new();
-	for i in 0..100_000_000 {
+	for i in 0..50_000_000 {
 		if random() {
 			val.insert(i);
 		}
@@ -52,16 +51,6 @@ fn bench_roaring_serialization_benchmark() {
 	}
 
 	// ASSERTIONS
-
-	debug!("Bincode::default, Bincode::options, Direct, Ratio direct/bincode::options");
-	// Direct is faster
-	debug!(
-		"Elapsed - {} > {} > {} - {}",
-		bincode_elapsed.as_micros(),
-		bincode_options_elapsed.as_micros(),
-		direct_elapsed.as_micros(),
-		direct_elapsed.as_micros() as f32 / bincode_options_elapsed.as_micros() as f32
-	);
 	assert!(
 		direct_elapsed < bincode_elapsed,
 		"direct_elapsed({direct_elapsed:?}) < bincode_elapsed({bincode_elapsed:?})"
@@ -69,13 +58,6 @@ fn bench_roaring_serialization_benchmark() {
 	let rate = direct_elapsed.as_micros() as f32 / bincode_options_elapsed.as_micros() as f32;
 	assert!(rate < 1.1, "rate({rate}) < 1.1");
 	// Direct is smaller
-	debug!(
-		"Size: {} > {} > {}  - {}",
-		bincode_size,
-		bincode_options_size,
-		direct_size,
-		direct_size as f32 / bincode_options_size as f32
-	);
 	assert!(
 		direct_size < bincode_size,
 		"direct_size({direct_size}) < bincode_size({bincode_size})"
@@ -88,7 +70,7 @@ fn bench_roaring_serialization_benchmark() {
 
 fn roaring_benchmark(c: &mut Criterion) {
 	let mut group = c.benchmark_group("roaring_benchmark");
-	group.sample_size(10).measurement_time(Duration::from_secs(10));
+	group.sample_size(10);
 	group.bench_function("bench_roaring_serialization_benchmark", |b| {
 		b.iter(bench_roaring_serialization_benchmark)
 	});

--- a/src/implementations/roaring.rs
+++ b/src/implementations/roaring.rs
@@ -39,8 +39,6 @@ impl Revisioned for RoaringBitmap {
 #[cfg(test)]
 mod tests {
 	use super::Revisioned;
-	use bincode::Options;
-	use rand::random;
 	use roaring::{RoaringBitmap, RoaringTreemap};
 
 	#[test]
@@ -63,56 +61,5 @@ mod tests {
 		let out =
 			<RoaringBitmap as Revisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
-	}
-
-	#[test]
-	fn test_roaring_serialization_space_benchmark() {
-		let mut val = RoaringTreemap::new();
-		for i in 0..1_000_000 {
-			if random() {
-				val.insert(i);
-			}
-		}
-
-		//Bincode with default options is: Bigger than direct serialization
-		let bincode_size;
-		{
-			let mut mem: Vec<u8> = vec![];
-			bincode::serialize_into(&mut mem, &val).unwrap();
-			bincode_size = mem.len();
-		}
-		//Bincode with options is: Bigger than direct serialization
-		let bincode_options_size;
-		{
-			let mut mem: Vec<u8> = vec![];
-			bincode::options()
-				.with_no_limit()
-				.with_little_endian()
-				.with_varint_encoding()
-				.reject_trailing_bytes()
-				.serialize_into(&mut mem, &val)
-				.unwrap();
-			bincode_options_size = mem.len();
-		}
-		//Direct serialization  is : Faster and smaller
-		let direct_size;
-		{
-			let mut mem: Vec<u8> = vec![];
-			val.serialize_into(&mut mem).unwrap();
-			direct_size = mem.len();
-		}
-
-		// ASSERTIONS
-
-		// Direct is smaller
-		println!(
-			"Size: {} > {} > {}  - {}",
-			bincode_size,
-			bincode_options_size,
-			direct_size,
-			direct_size as f32 / bincode_options_size as f32
-		);
-		assert!(direct_size < bincode_size);
-		assert!(direct_size < bincode_options_size);
 	}
 }


### PR DESCRIPTION
Move the time-oriented test from tests to benches. As benches are compiled with all optimisation.
Fixes the flaky issue on #13 