### PR TITLE
Fix missing attributes in re-expansion

### DIFF
--- a/derive/src/fields/mod.rs
+++ b/derive/src/fields/mod.rs
@@ -10,7 +10,7 @@ pub mod struct_inner;
 
 /// A parsed struct field alongside its attributes.
 #[derive(Debug, Eq, PartialEq, Clone, FromField)]
-#[darling(attributes(revision))]
+#[darling(attributes(revision), forward_attrs)]
 pub struct ParsedField {
 	ident: Option<syn::Ident>,
 	ty: syn::Type,


### PR DESCRIPTION
Turned out a attribute was missing on a struct parsing attributes, causing attributes to not be re-expanded.

This PR adds the missing attribute.