### PR TITLE
Fix attributes not being exported on enum variant fields

### DIFF
--- a/derive/src/fields/mod.rs
+++ b/derive/src/fields/mod.rs
@@ -40,5 +40,6 @@ struct ParsedEnumVariant {
 	default_fn: Option<String>,
 	#[darling(default)]
 	convert_fn: Option<String>,
+	fields: darling::ast::Fields<ParsedField>,
 	attrs: Vec<syn::Attribute>,
 }


### PR DESCRIPTION
The adding of the attribute fixed the missing attributes on tuple structs but on enum variants attributes still were not omitted.

This PR fixes this issue.