### PR TITLE
DB-501: Separate out serialization and deserialization into separate traits.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "revision"
 publish = true
 edition = "2021"
-version = "0.11.0"
+version = "0.12.0"
 license = "Apache-2.0"
 readme = "README.md"
 authors = ["Tobie Morgan Hitchcock <tobie@surrealdb.com>"]
@@ -21,7 +21,7 @@ default = []
 
 [dependencies]
 chrono = { version = "0.4.39", features = ["serde"], optional = true }
-derive = { version = "0.11.0", package = "revision-derive", path = "derive" }
+derive = { version = "0.12.0", package = "revision-derive", path = "derive" }
 geo = { version = "0.28.0", features = ["use-serde"], optional = true }
 ordered-float = { version = "4.2.2", optional = true }
 regex = { version = "1.10.6", optional = true }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -2,7 +2,7 @@
 name = "revision-derive"
 publish = true
 edition = "2021"
-version = "0.11.0"
+version = "0.12.0"
 license = "Apache-2.0"
 readme = "README.md"
 authors = ["Tobie Morgan Hitchcock <tobie@surrealdb.com>"]

--- a/derive/src/expand/common.rs
+++ b/derive/src/expand/common.rs
@@ -23,7 +23,7 @@ impl<'a> CalcDiscriminant<'a> {
 	}
 }
 
-impl<'a, 'ast> Visit<'ast> for CalcDiscriminant<'a> {
+impl<'ast> Visit<'ast> for CalcDiscriminant<'_> {
 	fn visit_enum(&mut self, i: &'ast crate::ast::Enum) -> syn::Result<()> {
 		GatherOverrides {
 			revision: self.revision,
@@ -60,7 +60,7 @@ pub struct GatherOverrides<'a> {
 	used: &'a mut HashSet<u32>,
 }
 
-impl<'a, 'ast> Visit<'ast> for GatherOverrides<'a> {
+impl<'ast> Visit<'ast> for GatherOverrides<'_> {
 	fn visit_variant(&mut self, i: &'ast crate::ast::Variant) -> syn::Result<()> {
 		if !i.attrs.options.exists_at(self.revision) {
 			return Ok(());

--- a/derive/src/expand/de.rs
+++ b/derive/src/expand/de.rs
@@ -23,7 +23,7 @@ impl<'a> EnumStructsVisitor<'a> {
 	}
 }
 
-impl<'a, 'ast> Visit<'ast> for EnumStructsVisitor<'a> {
+impl<'ast> Visit<'ast> for EnumStructsVisitor<'_> {
 	fn visit_enum(&mut self, i: &'ast Enum) -> syn::Result<()> {
 		for v in i.variants.iter() {
 			let name = v.fields_name(&i.name.to_string());
@@ -78,7 +78,7 @@ pub struct DeserializeVisitor<'a> {
 	pub stream: &'a mut TokenStream,
 }
 
-impl<'a, 'ast> Visit<'ast> for DeserializeVisitor<'a> {
+impl<'ast> Visit<'ast> for DeserializeVisitor<'_> {
 	fn visit_enum(&mut self, i: &'ast Enum) -> syn::Result<()> {
 		let mut discriminants = HashMap::new();
 		CalcDiscriminant::new(self.current, &mut discriminants).visit_enum(i)?;
@@ -195,7 +195,7 @@ pub struct DeserializeVariant<'a> {
 	pub discriminants: HashMap<Ident, u32>,
 }
 
-impl<'a, 'ast> Visit<'ast> for DeserializeVariant<'a> {
+impl<'ast> Visit<'ast> for DeserializeVariant<'_> {
 	fn visit_variant(&mut self, i: &'ast Variant) -> syn::Result<()> {
 		let exists_current = i.attrs.options.exists_at(self.current);
 		let exists_target = i.attrs.options.exists_at(self.target);
@@ -351,7 +351,7 @@ pub struct DeserializeFields<'a> {
 	pub stream: &'a mut TokenStream,
 }
 
-impl<'a, 'ast> Visit<'ast> for DeserializeFields<'a> {
+impl<'ast> Visit<'ast> for DeserializeFields<'_> {
 	fn visit_fields(&mut self, i: &'ast Fields) -> syn::Result<()> {
 		match *i {
 			Fields::Named {

--- a/derive/src/expand/de.rs
+++ b/derive/src/expand/de.rs
@@ -98,7 +98,7 @@ impl<'a, 'ast> Visit<'ast> for DeserializeVisitor<'a> {
 			format!("Invalid discriminant `{{x}}` for enum `{}` revision `{{__revision}}`", i.name);
 
 		self.stream.append_all(quote! {
-			let __discriminant = <u32 as ::revision::Revisioned>::deserialize_revisioned(reader)?;
+			let __discriminant = <u32 as ::revision::DeserializeRevisioned>::deserialize_revisioned(reader)?;
 			match __discriminant {
 				#variants
 				x => {
@@ -371,7 +371,7 @@ impl<'a, 'ast> Visit<'ast> for DeserializeFields<'a> {
 					if exists_target && exists_current {
 						let ty = &f.ty;
 						self.stream.append_all(quote! {
-							let #binding = <#ty as ::revision::Revisioned>::deserialize_revisioned(reader)?;
+							let #binding = <#ty as ::revision::DeserializeRevisioned>::deserialize_revisioned(reader)?;
 						})
 					} else if exists_target && !exists_current {
 						if let Some(default) = f.attrs.options.default.as_ref() {
@@ -388,7 +388,7 @@ impl<'a, 'ast> Visit<'ast> for DeserializeFields<'a> {
 					} else if !exists_target && exists_current {
 						let ty = &f.ty;
 						self.stream.append_all(quote! {
-							let #binding = <#ty as ::revision::Revisioned>::deserialize_revisioned(reader)?;
+							let #binding = <#ty as ::revision::DeserializeRevisioned>::deserialize_revisioned(reader)?;
 						})
 					}
 				}

--- a/derive/src/expand/mod.rs
+++ b/derive/src/expand/mod.rs
@@ -94,18 +94,16 @@ pub fn revision(attr: TokenStream, input: TokenStream) -> syn::Result<TokenStrea
 		#reexport
 		#deserialize_structs
 
-		impl ::revision::Revisioned for #name {
-			fn revision() -> u16{
-				#revision
-			}
-
+		impl ::revision::SerializeRevisioned for #name {
 			fn serialize_revisioned<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::result::Result<(), ::revision::Error> {
-				::revision::Revisioned::serialize_revisioned(&Self::revision(),writer)?;
+				::revision::SerializeRevisioned::serialize_revisioned(&<Self as ::revision::Revisioned>::revision(),writer)?;
 				#serialize
 			}
+		}
 
+		impl ::revision::DeserializeRevisioned for #name {
 			fn deserialize_revisioned<R: ::std::io::Read>(reader: &mut R) -> ::std::result::Result<Self, ::revision::Error> {
-				let __revision = <u16 as ::revision::Revisioned>::deserialize_revisioned(reader)?;
+				let __revision = <u16 as ::revision::DeserializeRevisioned>::deserialize_revisioned(reader)?;
 				match __revision {
 					#(#deserialize)*
 					x => {
@@ -114,6 +112,12 @@ pub fn revision(attr: TokenStream, input: TokenStream) -> syn::Result<TokenStrea
 						))
 					}
 				}
+			}
+		}
+
+		impl ::revision::Revisioned for #name {
+			fn revision() -> u16{
+				#revision
 			}
 		}
 	})

--- a/derive/src/expand/mod.rs
+++ b/derive/src/expand/mod.rs
@@ -4,8 +4,6 @@ mod reexport;
 mod ser;
 mod validate_version;
 
-use std::u16;
-
 use de::{DeserializeVisitor, EnumStructsVisitor};
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
@@ -90,32 +88,48 @@ pub fn revision(attr: TokenStream, input: TokenStream) -> syn::Result<TokenStrea
 	let revision = revision as u16;
 	let revision_error = format!("Invalid revision `{{}}` for type `{}`", name);
 
-	Ok(quote! {
-		#reexport
-		#deserialize_structs
-
-		impl ::revision::SerializeRevisioned for #name {
-			fn serialize_revisioned<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::result::Result<(), ::revision::Error> {
-				::revision::SerializeRevisioned::serialize_revisioned(&<Self as ::revision::Revisioned>::revision(),writer)?;
-				#serialize
+	let serialize_impl = if attrs.0.serialize {
+		quote! {
+			impl ::revision::SerializeRevisioned for #name {
+				fn serialize_revisioned<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::result::Result<(), ::revision::Error> {
+					::revision::SerializeRevisioned::serialize_revisioned(&<Self as ::revision::Revisioned>::revision(),writer)?;
+					#serialize
+				}
 			}
 		}
+	} else {
+		quote! {}
+	};
 
-		impl ::revision::DeserializeRevisioned for #name {
-			fn deserialize_revisioned<R: ::std::io::Read>(reader: &mut R) -> ::std::result::Result<Self, ::revision::Error> {
-				let __revision = <u16 as ::revision::DeserializeRevisioned>::deserialize_revisioned(reader)?;
-				match __revision {
-					#(#deserialize)*
-					x => {
-						return Err(::revision::Error::Deserialize(
-							format!(#revision_error,x)
-						))
+	let deserialize_impl = if attrs.0.deserialize {
+		quote! {
+			impl ::revision::DeserializeRevisioned for #name {
+				fn deserialize_revisioned<R: ::std::io::Read>(reader: &mut R) -> ::std::result::Result<Self, ::revision::Error> {
+					let __revision = <u16 as ::revision::DeserializeRevisioned>::deserialize_revisioned(reader)?;
+					match __revision {
+						#(#deserialize)*
+						x => {
+							return Err(::revision::Error::Deserialize(
+								format!(#revision_error,x)
+							))
+						}
 					}
 				}
 			}
 		}
+	} else {
+		quote! {}
+	};
+
+	Ok(quote! {
+		#reexport
+		#deserialize_structs
+
+		#serialize_impl
+		#deserialize_impl
 
 		impl ::revision::Revisioned for #name {
+			#[inline]
 			fn revision() -> u16{
 				#revision
 			}

--- a/derive/src/expand/reexport.rs
+++ b/derive/src/expand/reexport.rs
@@ -9,7 +9,7 @@ pub struct Reexport<'a> {
 	pub revision: usize,
 	pub stream: &'a mut TokenStream,
 }
-impl<'a, 'ast> Visit<'ast> for Reexport<'a> {
+impl<'ast> Visit<'ast> for Reexport<'_> {
 	fn visit_item(&mut self, i: &'ast ast::Item) -> syn::Result<()> {
 		for attr in i.attrs.other.iter() {
 			attr.to_tokens(self.stream)
@@ -146,7 +146,9 @@ impl<'a, 'ast> Visit<'ast> for Reexport<'a> {
 			ast::FieldName::Ident(ref x) => x.to_tokens(self.stream),
 			ast::FieldName::Index(_) => {}
 		}
-		i.colon_token.map(|x| x.to_tokens(self.stream));
+		if let Some(x) = i.colon_token {
+			x.to_tokens(self.stream);
+		}
 		i.ty.to_tokens(self.stream);
 		Ok(())
 	}

--- a/derive/src/expand/ser.rs
+++ b/derive/src/expand/ser.rs
@@ -90,7 +90,7 @@ impl<'a, 'ast> Visit<'ast> for SerializeVisitor<'a> {
 		let name = &i.name;
 
 		self.stream.append_all(quote! {
-			::revision::Revisioned::serialize_revisioned(#name,writer)?;
+			::revision::SerializeRevisioned::serialize_revisioned(#name,writer)?;
 		});
 
 		Ok(())
@@ -110,7 +110,7 @@ impl<'a, 'ast> Visit<'ast> for SerializeFields<'a> {
 
 		let name = i.name.to_binding();
 		self.stream.append_all(quote! {
-			::revision::Revisioned::serialize_revisioned(#name,writer)?;
+			::revision::SerializeRevisioned::serialize_revisioned(#name,writer)?;
 		});
 
 		Ok(())
@@ -160,7 +160,7 @@ impl<'a, 'ast> Visit<'ast> for SerializeVariant<'a> {
 
 				self.stream.append_all(quote! {
 					=> {
-						::revision::Revisioned::serialize_revisioned(&#discr,writer)?;
+						::revision::SerializeRevisioned::serialize_revisioned(&#discr,writer)?;
 						#fields_ser
 						Ok(())
 					},
@@ -189,7 +189,7 @@ impl<'a, 'ast> Visit<'ast> for SerializeVariant<'a> {
 
 				self.stream.append_all(quote! {
 					=> {
-						::revision::Revisioned::serialize_revisioned(&#discr,writer)?;
+						::revision::SerializeRevisioned::serialize_revisioned(&#discr,writer)?;
 						#fields_ser
 						Ok(())
 					}
@@ -197,7 +197,7 @@ impl<'a, 'ast> Visit<'ast> for SerializeVariant<'a> {
 			}
 			Fields::Unit => {
 				self.stream.append_all(quote! { => {
-					::revision::Revisioned::serialize_revisioned(&#discr,writer)?;
+					::revision::SerializeRevisioned::serialize_revisioned(&#discr,writer)?;
 					Ok(())
 				}});
 			}

--- a/derive/src/expand/ser.rs
+++ b/derive/src/expand/ser.rs
@@ -21,7 +21,7 @@ impl<'a> SerializeVisitor<'a> {
 	}
 }
 
-impl<'a, 'ast> Visit<'ast> for SerializeVisitor<'a> {
+impl<'ast> Visit<'ast> for SerializeVisitor<'_> {
 	fn visit_struct(&mut self, i: &'ast Struct) -> syn::Result<()> {
 		let mut ser_fields = TokenStream::new();
 		SerializeFields {
@@ -102,7 +102,7 @@ pub struct SerializeFields<'a> {
 	pub stream: &'a mut TokenStream,
 }
 
-impl<'a, 'ast> Visit<'ast> for SerializeFields<'a> {
+impl<'ast> Visit<'ast> for SerializeFields<'_> {
 	fn visit_field(&mut self, i: &'ast Field) -> syn::Result<()> {
 		if !i.attrs.options.exists_at(self.revision) {
 			return Ok(());
@@ -123,7 +123,7 @@ pub struct SerializeVariant<'a> {
 	pub stream: &'a mut TokenStream,
 }
 
-impl<'a, 'ast> Visit<'ast> for SerializeVariant<'a> {
+impl<'ast> Visit<'ast> for SerializeVariant<'_> {
 	fn visit_variant(&mut self, i: &'ast Variant) -> syn::Result<()> {
 		if !i.attrs.options.exists_at(self.revision) {
 			return Ok(());

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -60,6 +60,33 @@ mod expand;
 /// and removed in version 3. The generated code will ensure that this field
 /// will only be deserialized for version 2 of the structure.
 ///
+/// ## Disabling serialization or deserialization
+///
+/// You can disable serialization or deserialization of a struct by using the
+/// `#[revision(serialize = false)]` or `#[revision(deserialize = false)]`.
+/// This is useful for data migrations when you no longer want to write the
+/// struct but still want to read it or vice versa.
+///
+/// By default both serialization and deserialization are enabled.
+///
+/// ## Example
+///
+/// ```
+/// use revision::prelude::*;
+///
+/// #[derive(Debug)]
+/// #[revisioned(revision = 2, serialize = false)]
+/// struct ReadOnlyStruct {
+///    a: u32,
+/// }
+///
+/// #[derive(Debug)]
+/// #[revisioned(revision = 2, deserialize = false)]
+/// struct WriteOnlyStruct {
+///    a: u32,
+/// }
+/// ```
+///
 /// ## Supported field attributes and usage
 ///
 /// The struct field and enum variant `revision` attribute accepts several key-
@@ -176,7 +203,7 @@ mod expand;
 ///     }
 ///
 ///     fn convert_variant_three_field(fields: &mut SomeTupleTwoFields, _revision: u16, v: bool) -> Result<(), Error> {
-///			Ok(())
+///         Ok(())
 ///     }
 /// }
 /// ```

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,6 +26,7 @@ pub enum Error {
 }
 
 impl std::error::Error for Error {
+	#[inline]
 	fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
 		match self {
 			Error::Io(ref x) => Some(x),
@@ -36,6 +37,7 @@ impl std::error::Error for Error {
 }
 
 impl std::fmt::Display for Error {
+	#[inline]
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::result::Result<(), std::fmt::Error> {
 		match self {
 			Self::Io(e) => write!(f, "An IO error occured: {}", e),

--- a/src/implementations/arrays.rs
+++ b/src/implementations/arrays.rs
@@ -1,11 +1,14 @@
 use super::super::Error;
 use super::super::Revisioned;
+use super::super::SerializeRevisioned;
+use super::super::DeserializeRevisioned;
 
 macro_rules! impl_revisioned_array_with_size {
 	($ty:literal) => {
-		impl<T> Revisioned for [T; $ty]
+
+		impl<T> SerializeRevisioned for [T; $ty]
 		where
-			T: Copy + Default + Revisioned,
+			T: Copy + Default + SerializeRevisioned,
 		{
 			#[inline]
 			fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
@@ -14,7 +17,12 @@ macro_rules! impl_revisioned_array_with_size {
 				}
 				Ok(())
 			}
+		}
 
+		impl<T> DeserializeRevisioned for [T; $ty]
+		where
+			T: Copy + Default + DeserializeRevisioned,
+		{
 			#[inline]
 			fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
 				let mut array = [T::default(); $ty];
@@ -23,7 +31,12 @@ macro_rules! impl_revisioned_array_with_size {
 				}
 				Ok(array)
 			}
+		}
 
+		impl<T> Revisioned for [T; $ty]
+		where
+			T: Copy + Default + Revisioned,
+		{
 			fn revision() -> u16 {
 				1
 			}

--- a/src/implementations/arrays.rs
+++ b/src/implementations/arrays.rs
@@ -36,6 +36,7 @@ macro_rules! impl_revisioned_array_with_size {
 		where
 			T: Copy + Default + Revisioned,
 		{
+			#[inline]
 			fn revision() -> u16 {
 				1
 			}

--- a/src/implementations/arrays.rs
+++ b/src/implementations/arrays.rs
@@ -1,11 +1,10 @@
+use super::super::DeserializeRevisioned;
 use super::super::Error;
 use super::super::Revisioned;
 use super::super::SerializeRevisioned;
-use super::super::DeserializeRevisioned;
 
 macro_rules! impl_revisioned_array_with_size {
 	($ty:literal) => {
-
 		impl<T> SerializeRevisioned for [T; $ty]
 		where
 			T: Copy + Default + SerializeRevisioned,

--- a/src/implementations/bound.rs
+++ b/src/implementations/bound.rs
@@ -58,7 +58,8 @@ mod tests {
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 1);
 		let out =
-			<Bound<String> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+			<Bound<String> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
+				.unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -69,7 +70,8 @@ mod tests {
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 16);
 		let out =
-			<Bound<String> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+			<Bound<String> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
+				.unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -80,7 +82,8 @@ mod tests {
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 16);
 		let out =
-			<Bound<String> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+			<Bound<String> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
+				.unwrap();
 		assert_eq!(val, out);
 	}
 }

--- a/src/implementations/bound.rs
+++ b/src/implementations/bound.rs
@@ -1,8 +1,11 @@
+use crate::DeserializeRevisioned;
+use crate::SerializeRevisioned;
+
 use super::super::Error;
 use super::super::Revisioned;
 use std::ops::Bound;
 
-impl<T: Revisioned> Revisioned for Bound<T> {
+impl<T: SerializeRevisioned> SerializeRevisioned for Bound<T> {
 	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		match *self {
@@ -17,7 +20,9 @@ impl<T: Revisioned> Revisioned for Bound<T> {
 			}
 		}
 	}
+}
 
+impl<T: DeserializeRevisioned> DeserializeRevisioned for Bound<T> {
 	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
 		let variant = u32::deserialize_revisioned(reader)?;
@@ -34,7 +39,9 @@ impl<T: Revisioned> Revisioned for Bound<T> {
 			_ => Err(Error::Deserialize("Unknown variant index".to_string())),
 		}
 	}
+}
 
+impl<T: Revisioned> Revisioned for Bound<T> {
 	fn revision() -> u16 {
 		1
 	}
@@ -42,9 +49,7 @@ impl<T: Revisioned> Revisioned for Bound<T> {
 
 #[cfg(test)]
 mod tests {
-
-	use super::Bound;
-	use super::Revisioned;
+	use super::*;
 
 	#[test]
 	fn test_bound_unbounded() {
@@ -53,7 +58,7 @@ mod tests {
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 1);
 		let out =
-			<Bound<String> as Revisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+			<Bound<String> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -64,7 +69,7 @@ mod tests {
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 16);
 		let out =
-			<Bound<String> as Revisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+			<Bound<String> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -75,7 +80,7 @@ mod tests {
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 16);
 		let out =
-			<Bound<String> as Revisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+			<Bound<String> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 }

--- a/src/implementations/bound.rs
+++ b/src/implementations/bound.rs
@@ -42,6 +42,7 @@ impl<T: DeserializeRevisioned> DeserializeRevisioned for Bound<T> {
 }
 
 impl<T: Revisioned> Revisioned for Bound<T> {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}

--- a/src/implementations/boxes.rs
+++ b/src/implementations/boxes.rs
@@ -43,7 +43,9 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 15);
-		let out = <Box<String> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out =
+			<Box<String> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
+				.unwrap();
 		assert_eq!(val, out);
 	}
 }

--- a/src/implementations/boxes.rs
+++ b/src/implementations/boxes.rs
@@ -1,20 +1,33 @@
+use crate::DeserializeRevisioned;
+use crate::SerializeRevisioned;
+
 use super::super::Error;
 use super::super::Revisioned;
 
-impl<T> Revisioned for Box<T>
+impl<T> SerializeRevisioned for Box<T>
 where
-	T: Revisioned,
+	T: SerializeRevisioned,
 {
 	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		self.as_ref().serialize_revisioned(writer)
 	}
+}
 
+impl<T> DeserializeRevisioned for Box<T>
+where
+	T: DeserializeRevisioned,
+{
 	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
 		Ok(Box::new(T::deserialize_revisioned(reader)?))
 	}
+}
 
+impl<T> Revisioned for Box<T>
+where
+	T: Revisioned,
+{
 	fn revision() -> u16 {
 		1
 	}
@@ -22,8 +35,7 @@ where
 
 #[cfg(test)]
 mod tests {
-
-	use super::Revisioned;
+	use super::*;
 
 	#[test]
 	fn test_box() {
@@ -31,7 +43,7 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 15);
-		let out = <Box<String> as Revisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out = <Box<String> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 }

--- a/src/implementations/boxes.rs
+++ b/src/implementations/boxes.rs
@@ -28,6 +28,7 @@ impl<T> Revisioned for Box<T>
 where
 	T: Revisioned,
 {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}

--- a/src/implementations/chrono.rs
+++ b/src/implementations/chrono.rs
@@ -25,6 +25,7 @@ impl DeserializeRevisioned for DateTime<Utc> {
 }
 
 impl Revisioned for DateTime<Utc> {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}
@@ -52,6 +53,7 @@ impl DeserializeRevisioned for NaiveDate {
 }
 
 impl Revisioned for NaiveDate {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}
@@ -81,6 +83,7 @@ impl DeserializeRevisioned for NaiveTime {
 }
 
 impl Revisioned for NaiveTime {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}
@@ -121,6 +124,7 @@ impl DeserializeRevisioned for Duration {
 }
 
 impl Revisioned for Duration {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}

--- a/src/implementations/chrono.rs
+++ b/src/implementations/chrono.rs
@@ -1,32 +1,36 @@
 #![cfg(feature = "chrono")]
 
 use super::super::Error;
-use super::super::Revisioned;
+use super::super::{Revisioned, DeserializeRevisioned, SerializeRevisioned};
 use chrono::{offset::TimeZone, DateTime, Datelike, Duration, NaiveDate, NaiveTime, Timelike, Utc};
 
-impl Revisioned for DateTime<Utc> {
+impl SerializeRevisioned for DateTime<Utc> {
 	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		self.timestamp().serialize_revisioned(writer)?;
 		self.timestamp_subsec_nanos().serialize_revisioned(writer)?;
 		Ok(())
 	}
+}
 
+impl DeserializeRevisioned for DateTime<Utc> {
 	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
-		let secs = <i64 as Revisioned>::deserialize_revisioned(reader)?;
-		let nano = <u32 as Revisioned>::deserialize_revisioned(reader)?;
+		let secs = <i64 as DeserializeRevisioned>::deserialize_revisioned(reader)?;
+		let nano = <u32 as DeserializeRevisioned>::deserialize_revisioned(reader)?;
 		Utc.timestamp_opt(secs, nano)
 			.single()
 			.ok_or_else(|| Error::Deserialize("invalid datetime".to_string()))
 	}
+}
 
+impl Revisioned for DateTime<Utc> {
 	fn revision() -> u16 {
 		1
 	}
 }
 
-impl Revisioned for NaiveDate {
+impl SerializeRevisioned for NaiveDate {
 	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		self.year().serialize_revisioned(writer)?;
@@ -34,22 +38,26 @@ impl Revisioned for NaiveDate {
 		self.day().serialize_revisioned(writer)?;
 		Ok(())
 	}
+}
 
+impl DeserializeRevisioned for NaiveDate {
 	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
-		let year = <i32 as Revisioned>::deserialize_revisioned(reader)?;
-		let month = <u32 as Revisioned>::deserialize_revisioned(reader)?;
-		let day = <u32 as Revisioned>::deserialize_revisioned(reader)?;
+		let year = <i32 as DeserializeRevisioned>::deserialize_revisioned(reader)?;
+		let month = <u32 as DeserializeRevisioned>::deserialize_revisioned(reader)?;
+		let day = <u32 as DeserializeRevisioned>::deserialize_revisioned(reader)?;
 		NaiveDate::from_ymd_opt(year, month, day)
 			.ok_or_else(|| Error::Deserialize("invalid date".to_string()))
 	}
+}
 
+impl Revisioned for NaiveDate {
 	fn revision() -> u16 {
 		1
 	}
 }
 
-impl Revisioned for NaiveTime {
+impl SerializeRevisioned for NaiveTime {
 	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		self.hour().serialize_revisioned(writer)?;
@@ -58,23 +66,27 @@ impl Revisioned for NaiveTime {
 		self.nanosecond().serialize_revisioned(writer)?;
 		Ok(())
 	}
+}
 
+impl DeserializeRevisioned for NaiveTime {
 	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
-		let hour = <u32 as Revisioned>::deserialize_revisioned(reader)?;
-		let minute = <u32 as Revisioned>::deserialize_revisioned(reader)?;
-		let second = <u32 as Revisioned>::deserialize_revisioned(reader)?;
-		let nano = <u32 as Revisioned>::deserialize_revisioned(reader)?;
+		let hour = <u32 as DeserializeRevisioned>::deserialize_revisioned(reader)?;
+		let minute = <u32 as DeserializeRevisioned>::deserialize_revisioned(reader)?;
+		let second = <u32 as DeserializeRevisioned>::deserialize_revisioned(reader)?;
+		let nano = <u32 as DeserializeRevisioned>::deserialize_revisioned(reader)?;
 		NaiveTime::from_hms_nano_opt(hour, minute, second, nano)
 			.ok_or_else(|| Error::Deserialize("invalid time".to_string()))
 	}
+}
 
+impl Revisioned for NaiveTime {
 	fn revision() -> u16 {
 		1
 	}
 }
 
-impl Revisioned for Duration {
+impl SerializeRevisioned for Duration {
 	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		let mut secs = self.num_seconds();
@@ -94,17 +106,21 @@ impl Revisioned for Duration {
 
 		Ok(())
 	}
+}
 
+impl DeserializeRevisioned for Duration {
 	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
-		let secs = <i64 as Revisioned>::deserialize_revisioned(reader)?;
-		let nano = <i32 as Revisioned>::deserialize_revisioned(reader)?;
+		let secs = <i64 as DeserializeRevisioned>::deserialize_revisioned(reader)?;
+		let nano = <i32 as DeserializeRevisioned>::deserialize_revisioned(reader)?;
 		let nano =
 			u32::try_from(nano).map_err(|_| Error::Deserialize("invalid duration".to_string()))?;
 
 		Duration::new(secs, nano).ok_or_else(|| Error::Deserialize("invalid duration".to_string()))
 	}
+}
 
+impl Revisioned for Duration {
 	fn revision() -> u16 {
 		1
 	}
@@ -112,10 +128,7 @@ impl Revisioned for Duration {
 
 #[cfg(test)]
 mod tests {
-	use super::DateTime;
-	use super::Revisioned;
-	use super::Utc;
-	use chrono::{Duration, NaiveDate, NaiveTime};
+	use super::*;
 
 	#[test]
 	fn test_datetime_min() {
@@ -124,7 +137,7 @@ mod tests {
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 10);
 		let out =
-			<DateTime<Utc> as Revisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+			<DateTime<Utc> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -135,7 +148,7 @@ mod tests {
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 14);
 		let out =
-			<DateTime<Utc> as Revisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+			<DateTime<Utc> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -145,7 +158,7 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 3);
-		let out = <NaiveDate as Revisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out = <NaiveDate as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -155,7 +168,7 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 5);
-		let out = <NaiveDate as Revisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out = <NaiveDate as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -165,7 +178,7 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 4);
-		let out = <NaiveTime as Revisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out = <NaiveTime as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -175,7 +188,7 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 8);
-		let out = <NaiveTime as Revisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out = <NaiveTime as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -185,7 +198,7 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 14);
-		let out = <Duration as Revisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out = <Duration as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -195,7 +208,7 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 2);
-		let out = <Duration as Revisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out = <Duration as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -205,7 +218,7 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 14);
-		let out = <Duration as Revisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out = <Duration as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 }

--- a/src/implementations/chrono.rs
+++ b/src/implementations/chrono.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "chrono")]
 
 use super::super::Error;
-use super::super::{Revisioned, DeserializeRevisioned, SerializeRevisioned};
+use super::super::{DeserializeRevisioned, Revisioned, SerializeRevisioned};
 use chrono::{offset::TimeZone, DateTime, Datelike, Duration, NaiveDate, NaiveTime, Timelike, Utc};
 
 impl SerializeRevisioned for DateTime<Utc> {
@@ -137,7 +137,8 @@ mod tests {
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 10);
 		let out =
-			<DateTime<Utc> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+			<DateTime<Utc> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
+				.unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -148,7 +149,8 @@ mod tests {
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 14);
 		let out =
-			<DateTime<Utc> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+			<DateTime<Utc> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
+				.unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -158,7 +160,8 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 3);
-		let out = <NaiveDate as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out = <NaiveDate as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
+			.unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -168,7 +171,8 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 5);
-		let out = <NaiveDate as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out = <NaiveDate as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
+			.unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -178,7 +182,8 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 4);
-		let out = <NaiveTime as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out = <NaiveTime as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
+			.unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -188,7 +193,8 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 8);
-		let out = <NaiveTime as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out = <NaiveTime as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
+			.unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -198,7 +204,8 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 14);
-		let out = <Duration as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out = <Duration as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
+			.unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -208,7 +215,8 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 2);
-		let out = <Duration as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out = <Duration as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
+			.unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -218,7 +226,8 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 14);
-		let out = <Duration as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out = <Duration as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
+			.unwrap();
 		assert_eq!(val, out);
 	}
 }

--- a/src/implementations/cow.rs
+++ b/src/implementations/cow.rs
@@ -32,6 +32,7 @@ where
 	T: Sized + ToOwned + Revisioned,
 	T::Owned: Revisioned,
 {
+	#[inline]
 	fn revision() -> u16 {
 		T::revision()
 	}

--- a/src/implementations/decimal.rs
+++ b/src/implementations/decimal.rs
@@ -1,22 +1,26 @@
 #![cfg(feature = "rust_decimal")]
 
 use super::super::Error;
-use super::super::Revisioned;
+use super::super::{Revisioned, DeserializeRevisioned, SerializeRevisioned};
 use rust_decimal::Decimal;
 
-impl Revisioned for Decimal {
+impl SerializeRevisioned for Decimal {
 	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		writer.write_all(self.serialize().as_slice()).map_err(Error::Io)
 	}
+}
 
+impl DeserializeRevisioned for Decimal {
 	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
 		let mut b = [0u8; 16];
 		reader.read_exact(&mut b).map_err(Error::Io)?;
 		Ok(Decimal::deserialize(b))
 	}
+}
 
+impl Revisioned for Decimal {
 	fn revision() -> u16 {
 		1
 	}
@@ -25,8 +29,7 @@ impl Revisioned for Decimal {
 #[cfg(test)]
 mod tests {
 
-	use super::Decimal;
-	use super::Revisioned;
+	use super::*;
 
 	#[test]
 	fn test_decimal_min() {
@@ -34,7 +37,7 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 16);
-		let out = <Decimal as Revisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out = <Decimal as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -44,7 +47,7 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 16);
-		let out = <Decimal as Revisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out = <Decimal as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 }

--- a/src/implementations/decimal.rs
+++ b/src/implementations/decimal.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "rust_decimal")]
 
 use super::super::Error;
-use super::super::{Revisioned, DeserializeRevisioned, SerializeRevisioned};
+use super::super::{DeserializeRevisioned, Revisioned, SerializeRevisioned};
 use rust_decimal::Decimal;
 
 impl SerializeRevisioned for Decimal {
@@ -37,7 +37,8 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 16);
-		let out = <Decimal as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out = <Decimal as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
+			.unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -47,7 +48,8 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 16);
-		let out = <Decimal as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out = <Decimal as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
+			.unwrap();
 		assert_eq!(val, out);
 	}
 }

--- a/src/implementations/decimal.rs
+++ b/src/implementations/decimal.rs
@@ -21,6 +21,7 @@ impl DeserializeRevisioned for Decimal {
 }
 
 impl Revisioned for Decimal {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}

--- a/src/implementations/duration.rs
+++ b/src/implementations/duration.rs
@@ -1,21 +1,28 @@
+use crate::DeserializeRevisioned;
+use crate::SerializeRevisioned;
+
 use super::super::Error;
 use super::super::Revisioned;
 use std::time::Duration;
 
-impl Revisioned for Duration {
+impl SerializeRevisioned for Duration {
 	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		self.as_secs().serialize_revisioned(writer)?;
 		self.subsec_nanos().serialize_revisioned(writer)
 	}
+}
 
+impl DeserializeRevisioned for Duration {
 	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
 		let secs = u64::deserialize_revisioned(reader)?;
 		let nanos = u32::deserialize_revisioned(reader)?;
 		Ok(Duration::new(secs, nanos))
 	}
+}
 
+impl Revisioned for Duration {
 	fn revision() -> u16 {
 		1
 	}
@@ -25,8 +32,7 @@ impl Revisioned for Duration {
 mod tests {
 	use crate::implementations::assert_bincode_compat;
 
-	use super::Duration;
-	use super::Revisioned;
+	use super::*;
 
 	#[test]
 	fn test_string() {
@@ -34,7 +40,7 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 6);
-		let out = <Duration as Revisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out = <Duration as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 

--- a/src/implementations/duration.rs
+++ b/src/implementations/duration.rs
@@ -23,6 +23,7 @@ impl DeserializeRevisioned for Duration {
 }
 
 impl Revisioned for Duration {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}

--- a/src/implementations/duration.rs
+++ b/src/implementations/duration.rs
@@ -40,7 +40,8 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 6);
-		let out = <Duration as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out = <Duration as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
+			.unwrap();
 		assert_eq!(val, out);
 	}
 

--- a/src/implementations/geo.rs
+++ b/src/implementations/geo.rs
@@ -26,6 +26,7 @@ impl DeserializeRevisioned for Coord {
 }
 
 impl Revisioned for Coord {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}
@@ -46,6 +47,7 @@ impl DeserializeRevisioned for Point {
 }
 
 impl Revisioned for Point {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}
@@ -66,6 +68,7 @@ impl DeserializeRevisioned for LineString {
 }
 
 impl Revisioned for LineString {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}
@@ -90,6 +93,7 @@ impl DeserializeRevisioned for Polygon {
 }
 
 impl Revisioned for Polygon {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}
@@ -110,6 +114,7 @@ impl DeserializeRevisioned for MultiPoint {
 }
 
 impl Revisioned for MultiPoint {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}
@@ -130,6 +135,7 @@ impl DeserializeRevisioned for MultiLineString {
 }
 
 impl Revisioned for MultiLineString {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}
@@ -150,6 +156,7 @@ impl DeserializeRevisioned for MultiPolygon {
 }
 
 impl Revisioned for MultiPolygon {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}

--- a/src/implementations/geo.rs
+++ b/src/implementations/geo.rs
@@ -1,9 +1,9 @@
 #![cfg(feature = "geo")]
 
 use super::super::Error;
-use super::super::{Revisioned, DeserializeRevisioned, SerializeRevisioned};
+use super::super::{DeserializeRevisioned, Revisioned, SerializeRevisioned};
 use super::vecs::serialize_slice;
-use geo::{Coord, Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon};
+use geo::{Coord, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon};
 
 impl SerializeRevisioned for Coord {
 	#[inline]

--- a/src/implementations/geo.rs
+++ b/src/implementations/geo.rs
@@ -1,16 +1,19 @@
 #![cfg(feature = "geo")]
 
 use super::super::Error;
-use super::super::Revisioned;
+use super::super::{Revisioned, DeserializeRevisioned, SerializeRevisioned};
 use super::vecs::serialize_slice;
+use geo::{Coord, Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon};
 
-impl Revisioned for geo::Coord {
+impl SerializeRevisioned for Coord {
 	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		self.x.serialize_revisioned(writer)?;
 		self.y.serialize_revisioned(writer)
 	}
+}
 
+impl DeserializeRevisioned for Coord {
 	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
 		let x = f64::deserialize_revisioned(reader)?;
@@ -20,107 +23,133 @@ impl Revisioned for geo::Coord {
 			y,
 		})
 	}
+}
 
+impl Revisioned for Coord {
 	fn revision() -> u16 {
 		1
 	}
 }
 
-impl Revisioned for geo::Point {
+impl SerializeRevisioned for Point {
 	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		self.0.serialize_revisioned(writer)
 	}
+}
 
+impl DeserializeRevisioned for Point {
 	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
-		Ok(Self(Revisioned::deserialize_revisioned(reader)?))
+		Ok(Self(DeserializeRevisioned::deserialize_revisioned(reader)?))
 	}
+}
 
+impl Revisioned for Point {
 	fn revision() -> u16 {
 		1
 	}
 }
 
-impl Revisioned for geo::LineString {
+impl SerializeRevisioned for LineString {
 	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		self.0.serialize_revisioned(writer)
 	}
+}
 
+impl DeserializeRevisioned for LineString {
 	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
-		Ok(Self(Revisioned::deserialize_revisioned(reader)?))
+		Ok(Self(DeserializeRevisioned::deserialize_revisioned(reader)?))
 	}
+}
 
+impl Revisioned for LineString {
 	fn revision() -> u16 {
 		1
 	}
 }
 
-impl Revisioned for geo::Polygon {
+impl SerializeRevisioned for Polygon {
 	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		self.exterior().serialize_revisioned(writer)?;
 		serialize_slice(self.interiors(), writer)
 	}
+}
 
+impl DeserializeRevisioned for Polygon {
 	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
 		Ok(Self::new(
-			Revisioned::deserialize_revisioned(reader)?,
-			Revisioned::deserialize_revisioned(reader)?,
+			DeserializeRevisioned::deserialize_revisioned(reader)?,
+			DeserializeRevisioned::deserialize_revisioned(reader)?,
 		))
 	}
+}
 
+impl Revisioned for Polygon {
 	fn revision() -> u16 {
 		1
 	}
 }
 
-impl Revisioned for geo::MultiPoint {
+impl SerializeRevisioned for MultiPoint {
 	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		self.0.serialize_revisioned(writer)
 	}
+}
 
+impl DeserializeRevisioned for MultiPoint {
 	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
-		Ok(Self(Revisioned::deserialize_revisioned(reader)?))
+		Ok(Self(DeserializeRevisioned::deserialize_revisioned(reader)?))
 	}
+}
 
+impl Revisioned for MultiPoint {
 	fn revision() -> u16 {
 		1
 	}
 }
 
-impl Revisioned for geo::MultiLineString {
+impl SerializeRevisioned for MultiLineString {
 	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		self.0.serialize_revisioned(writer)
 	}
+}
 
+impl DeserializeRevisioned for MultiLineString {
 	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
-		Ok(Self(Revisioned::deserialize_revisioned(reader)?))
+		Ok(Self(DeserializeRevisioned::deserialize_revisioned(reader)?))
 	}
+}
 
+impl Revisioned for MultiLineString {
 	fn revision() -> u16 {
 		1
 	}
 }
 
-impl Revisioned for geo::MultiPolygon {
+impl SerializeRevisioned for MultiPolygon {
 	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		self.0.serialize_revisioned(writer)
 	}
+}
 
+impl DeserializeRevisioned for MultiPolygon {
 	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
-		Ok(Self(Revisioned::deserialize_revisioned(reader)?))
+		Ok(Self(DeserializeRevisioned::deserialize_revisioned(reader)?))
 	}
+}
 
+impl Revisioned for MultiPolygon {
 	fn revision() -> u16 {
 		1
 	}
@@ -130,7 +159,7 @@ impl Revisioned for geo::MultiPolygon {
 mod test {
 	use std::cell::Cell;
 
-	use geo::{Coord, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon};
+	use super::*;
 
 	use crate::implementations::assert_bincode_compat;
 

--- a/src/implementations/mod.rs
+++ b/src/implementations/mod.rs
@@ -25,7 +25,7 @@ pub mod wrapping;
 #[track_caller]
 pub fn assert_bincode_compat<T>(v: &T)
 where
-	T: serde::Serialize + crate::Revisioned,
+	T: serde::Serialize + crate::SerializeRevisioned,
 {
 	use bincode::Options;
 

--- a/src/implementations/notnan.rs
+++ b/src/implementations/notnan.rs
@@ -20,8 +20,8 @@ where
 {
 	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
-		Ok(NotNan::new(T::deserialize_revisioned(reader)?)
-			.map_err(|e| Error::Deserialize(format!("{:?}", e)))?)
+		NotNan::new(T::deserialize_revisioned(reader)?)
+			.map_err(|e| Error::Deserialize(format!("{:?}", e)))
 	}
 }
 
@@ -29,6 +29,7 @@ impl<T> Revisioned for NotNan<T>
 where
 	T: Revisioned + FloatCore,
 {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}

--- a/src/implementations/notnan.rs
+++ b/src/implementations/notnan.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "ordered-float")]
 
 use super::super::Error;
-use super::super::{Revisioned, DeserializeRevisioned, SerializeRevisioned};
+use super::super::{DeserializeRevisioned, Revisioned, SerializeRevisioned};
 use ordered_float::{FloatCore, NotNan};
 
 impl<T> SerializeRevisioned for NotNan<T>
@@ -45,7 +45,9 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 4);
-		let out = <NotNan<f32> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out =
+			<NotNan<f32> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
+				.unwrap();
 		assert_eq!(val, out);
 	}
 }

--- a/src/implementations/notnan.rs
+++ b/src/implementations/notnan.rs
@@ -1,24 +1,34 @@
 #![cfg(feature = "ordered-float")]
 
 use super::super::Error;
-use super::super::Revisioned;
+use super::super::{Revisioned, DeserializeRevisioned, SerializeRevisioned};
 use ordered_float::{FloatCore, NotNan};
 
-impl<T> Revisioned for NotNan<T>
+impl<T> SerializeRevisioned for NotNan<T>
 where
-	T: Revisioned + FloatCore,
+	T: SerializeRevisioned + FloatCore,
 {
 	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		self.as_ref().serialize_revisioned(writer)
 	}
+}
 
+impl<T> DeserializeRevisioned for NotNan<T>
+where
+	T: DeserializeRevisioned + FloatCore,
+{
 	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
-		NotNan::new(T::deserialize_revisioned(reader)?)
-			.map_err(|e| Error::Deserialize(format!("{:?}", e)))
+		Ok(NotNan::new(T::deserialize_revisioned(reader)?)
+			.map_err(|e| Error::Deserialize(format!("{:?}", e)))?)
 	}
+}
 
+impl<T> Revisioned for NotNan<T>
+where
+	T: Revisioned + FloatCore,
+{
 	fn revision() -> u16 {
 		1
 	}
@@ -27,8 +37,7 @@ where
 #[cfg(test)]
 mod tests {
 
-	use super::Revisioned;
-	use ordered_float::NotNan;
+	use super::*;
 
 	#[test]
 	fn test_wrapping() {
@@ -36,7 +45,7 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 4);
-		let out = <NotNan<f32> as Revisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out = <NotNan<f32> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 }

--- a/src/implementations/option.rs
+++ b/src/implementations/option.rs
@@ -39,7 +39,6 @@ impl<T> Revisioned for Option<T>
 where
 	T: Revisioned,
 {
-
 	fn revision() -> u16 {
 		1
 	}
@@ -57,7 +56,8 @@ mod tests {
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 1);
 		let out =
-			<Option<String> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+			<Option<String> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
+				.unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -68,7 +68,8 @@ mod tests {
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 16);
 		let out =
-			<Option<String> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+			<Option<String> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
+				.unwrap();
 		assert_eq!(val, out);
 	}
 }

--- a/src/implementations/option.rs
+++ b/src/implementations/option.rs
@@ -39,6 +39,7 @@ impl<T> Revisioned for Option<T>
 where
 	T: Revisioned,
 {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}

--- a/src/implementations/option.rs
+++ b/src/implementations/option.rs
@@ -1,9 +1,12 @@
+use crate::DeserializeRevisioned;
+use crate::SerializeRevisioned;
+
 use super::super::Error;
 use super::super::Revisioned;
 
-impl<T> Revisioned for Option<T>
+impl<T> SerializeRevisioned for Option<T>
 where
-	T: Revisioned,
+	T: SerializeRevisioned,
 {
 	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
@@ -15,7 +18,12 @@ where
 			None => 0u8.serialize_revisioned(writer),
 		}
 	}
+}
 
+impl<T> DeserializeRevisioned for Option<T>
+where
+	T: DeserializeRevisioned,
+{
 	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
 		let option = u8::deserialize_revisioned(reader)?;
@@ -25,6 +33,12 @@ where
 			value => Err(Error::Deserialize(format!("Invalid option value {}", value))),
 		}
 	}
+}
+
+impl<T> Revisioned for Option<T>
+where
+	T: Revisioned,
+{
 
 	fn revision() -> u16 {
 		1
@@ -34,7 +48,7 @@ where
 #[cfg(test)]
 mod tests {
 
-	use super::Revisioned;
+	use super::*;
 
 	#[test]
 	fn test_option_none() {
@@ -43,7 +57,7 @@ mod tests {
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 1);
 		let out =
-			<Option<String> as Revisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+			<Option<String> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -54,7 +68,7 @@ mod tests {
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 16);
 		let out =
-			<Option<String> as Revisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+			<Option<String> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 }

--- a/src/implementations/path.rs
+++ b/src/implementations/path.rs
@@ -1,10 +1,13 @@
 use std::path::PathBuf;
 
+use crate::DeserializeRevisioned;
+use crate::SerializeRevisioned;
+
 use super::super::Error;
 use super::super::Revisioned;
 use super::vecs::serialize_slice;
 
-impl Revisioned for PathBuf {
+impl SerializeRevisioned for PathBuf {
 	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		match self.to_str() {
@@ -12,13 +15,17 @@ impl Revisioned for PathBuf {
 			None => Err(Error::InvalidPath),
 		}
 	}
+}
 
+impl DeserializeRevisioned for PathBuf {
 	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
 		let s = String::deserialize_revisioned(reader)?;
 		Ok(PathBuf::from(s))
 	}
+}
 
+impl Revisioned for PathBuf {
 	fn revision() -> u16 {
 		1
 	}
@@ -31,7 +38,7 @@ mod tests {
 
 	use crate::implementations::assert_bincode_compat;
 
-	use super::Revisioned;
+	use super::*;
 
 	#[test]
 	fn test_pathbuf() {
@@ -40,7 +47,7 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 23);
-		let out = <PathBuf as Revisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out = <PathBuf as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 }

--- a/src/implementations/path.rs
+++ b/src/implementations/path.rs
@@ -47,7 +47,8 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 23);
-		let out = <PathBuf as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out = <PathBuf as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
+			.unwrap();
 		assert_eq!(val, out);
 	}
 }

--- a/src/implementations/path.rs
+++ b/src/implementations/path.rs
@@ -26,6 +26,7 @@ impl DeserializeRevisioned for PathBuf {
 }
 
 impl Revisioned for PathBuf {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}

--- a/src/implementations/primitives.rs
+++ b/src/implementations/primitives.rs
@@ -3,6 +3,7 @@ use std::io;
 use super::super::Revisioned;
 use crate::{DeserializeRevisioned, Error, SerializeRevisioned};
 
+#[inline]
 pub fn read_buffer<const COUNT: usize, R: io::Read>(reader: &mut R) -> Result<[u8; COUNT], Error> {
 	let mut buffer = [0u8; COUNT];
 	reader.read_exact(&mut buffer).map_err(Error::Io)?;
@@ -137,6 +138,7 @@ where
 }
 
 impl SerializeRevisioned for bool {
+	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, w: &mut W) -> Result<(), Error> {
 		let v = *self as u8;
 		w.write(&[v]).map_err(Error::Io)?;
@@ -145,6 +147,7 @@ impl SerializeRevisioned for bool {
 }
 
 impl DeserializeRevisioned for bool {
+	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(r: &mut R) -> Result<Self, Error> {
 		let buffer = read_buffer::<1, _>(r)?;
 		match buffer[0] {
@@ -156,18 +159,21 @@ impl DeserializeRevisioned for bool {
 }
 
 impl Revisioned for bool {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}
 }
 
 impl SerializeRevisioned for usize {
+	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, w: &mut W) -> Result<(), Error> {
 		((*self) as u64).serialize_revisioned(w)
 	}
 }
 
 impl DeserializeRevisioned for usize {
+	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(r: &mut R) -> Result<Self, Error>
 	where
 		Self: Sized,
@@ -177,18 +183,21 @@ impl DeserializeRevisioned for usize {
 }
 
 impl Revisioned for usize {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}
 }
 
 impl SerializeRevisioned for isize {
+	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, w: &mut W) -> Result<(), Error> {
 		((*self) as i64).serialize_revisioned(w)
 	}
 }
 
 impl DeserializeRevisioned for isize {
+	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(r: &mut R) -> Result<Self, Error>
 	where
 		Self: Sized,
@@ -198,18 +207,21 @@ impl DeserializeRevisioned for isize {
 }
 
 impl Revisioned for isize {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}
 }
 
 impl SerializeRevisioned for u8 {
+	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		writer.write_all(&[*self]).map_err(Error::Io)
 	}
 }
 
 impl DeserializeRevisioned for u8 {
+	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error>
 	where
 		Self: Sized,
@@ -219,18 +231,21 @@ impl DeserializeRevisioned for u8 {
 }
 
 impl Revisioned for u8 {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}
 }
 
 impl SerializeRevisioned for i8 {
+	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		writer.write_all(&[*self as u8]).map_err(Error::Io)
 	}
 }
 
 impl DeserializeRevisioned for i8 {
+	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error>
 	where
 		Self: Sized,
@@ -240,6 +255,7 @@ impl DeserializeRevisioned for i8 {
 }
 
 impl Revisioned for i8 {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}
@@ -265,6 +281,7 @@ macro_rules! impl_revisioned_int {
 		}
 
 		impl Revisioned for $ty {
+			#[inline]
 			fn revision() -> u16 {
 				1
 			}
@@ -293,6 +310,7 @@ macro_rules! impl_revisioned_signed_int {
 		}
 
 		impl Revisioned for $ty {
+			#[inline]
 			fn revision() -> u16 {
 				1
 			}
@@ -309,12 +327,14 @@ impl_revisioned_signed_int!(i32);
 impl_revisioned_signed_int!(i64);
 
 impl SerializeRevisioned for i128 {
+	#[inline]
 	fn serialize_revisioned<W: io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		encode_u128(writer, zigzag_128(*self))
 	}
 }
 
 impl DeserializeRevisioned for i128 {
+	#[inline]
 	fn deserialize_revisioned<R: io::Read>(reader: &mut R) -> Result<Self, Error>
 	where
 		Self: Sized,
@@ -324,18 +344,21 @@ impl DeserializeRevisioned for i128 {
 }
 
 impl Revisioned for i128 {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}
 }
 
 impl SerializeRevisioned for u128 {
+	#[inline]
 	fn serialize_revisioned<W: io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		encode_u128(writer, *self)
 	}
 }
 
 impl DeserializeRevisioned for u128 {
+	#[inline]
 	fn deserialize_revisioned<R: io::Read>(reader: &mut R) -> Result<Self, Error>
 	where
 		Self: Sized,
@@ -345,12 +368,14 @@ impl DeserializeRevisioned for u128 {
 }
 
 impl Revisioned for u128 {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}
 }
 
 impl SerializeRevisioned for f32 {
+	#[inline]
 	fn serialize_revisioned<W: io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		let bytes = self.to_le_bytes();
 		writer.write_all(&bytes).map_err(Error::Io)
@@ -358,6 +383,7 @@ impl SerializeRevisioned for f32 {
 }
 
 impl DeserializeRevisioned for f32 {
+	#[inline]
 	fn deserialize_revisioned<R: io::Read>(reader: &mut R) -> Result<Self, Error>
 	where
 		Self: Sized,
@@ -368,12 +394,14 @@ impl DeserializeRevisioned for f32 {
 }
 
 impl Revisioned for f32 {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}
 }
 
 impl SerializeRevisioned for f64 {
+	#[inline]
 	fn serialize_revisioned<W: io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		let bytes = self.to_le_bytes();
 		writer.write_all(&bytes).map_err(Error::Io)
@@ -381,6 +409,7 @@ impl SerializeRevisioned for f64 {
 }
 
 impl DeserializeRevisioned for f64 {
+	#[inline]
 	fn deserialize_revisioned<R: io::Read>(reader: &mut R) -> Result<Self, Error>
 	where
 		Self: Sized,
@@ -391,6 +420,7 @@ impl DeserializeRevisioned for f64 {
 }
 
 impl Revisioned for f64 {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}

--- a/src/implementations/primitives.rs
+++ b/src/implementations/primitives.rs
@@ -431,7 +431,8 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 1);
-		let out = <bool as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out =
+			<bool as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -441,7 +442,8 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 9);
-		let out = <isize as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out =
+			<isize as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -451,7 +453,8 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 1);
-		let out = <i8 as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out =
+			<i8 as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -461,7 +464,8 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 3);
-		let out = <i16 as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out =
+			<i16 as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -471,7 +475,8 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 5);
-		let out = <i32 as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out =
+			<i32 as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -481,7 +486,8 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 9);
-		let out = <i64 as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out =
+			<i64 as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -491,7 +497,8 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 17);
-		let out = <i128 as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out =
+			<i128 as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -501,7 +508,8 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 9);
-		let out = <usize as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out =
+			<usize as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -511,7 +519,8 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 1);
-		let out = <u8 as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out =
+			<u8 as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -521,7 +530,8 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 3);
-		let out = <u16 as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out =
+			<u16 as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -531,7 +541,8 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 5);
-		let out = <u32 as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out =
+			<u32 as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -541,7 +552,8 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 9);
-		let out = <u64 as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out =
+			<u64 as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -551,7 +563,8 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 17);
-		let out = <u128 as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out =
+			<u128 as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -561,7 +574,8 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 4);
-		let out = <f32 as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out =
+			<f32 as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -571,7 +585,8 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 8);
-		let out = <f64 as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out =
+			<f64 as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -581,7 +596,8 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 4);
-		let out = <char as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out =
+			<char as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 

--- a/src/implementations/regex.rs
+++ b/src/implementations/regex.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "regex")]
 
 use super::super::Error;
-use super::super::{Revisioned, DeserializeRevisioned, SerializeRevisioned};
+use super::super::{DeserializeRevisioned, Revisioned, SerializeRevisioned};
 use super::vecs::serialize_slice;
 use regex::Regex;
 
@@ -36,7 +36,8 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 23);
-		let out = <Regex as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out =
+			<Regex as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val.as_str(), out.as_str());
 	}
 }

--- a/src/implementations/regex.rs
+++ b/src/implementations/regex.rs
@@ -1,22 +1,26 @@
 #![cfg(feature = "regex")]
 
 use super::super::Error;
-use super::super::Revisioned;
+use super::super::{Revisioned, DeserializeRevisioned, SerializeRevisioned};
 use super::vecs::serialize_slice;
 use regex::Regex;
 
-impl Revisioned for Regex {
+impl SerializeRevisioned for Regex {
 	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		serialize_slice(self.as_str().as_bytes(), writer)
 	}
+}
 
+impl DeserializeRevisioned for Regex {
 	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
 		let s = String::deserialize_revisioned(reader)?;
 		s.parse().map_err(|_| Error::Deserialize("invalid regex".to_string()))
 	}
+}
 
+impl Revisioned for Regex {
 	fn revision() -> u16 {
 		1
 	}
@@ -24,9 +28,7 @@ impl Revisioned for Regex {
 
 #[cfg(test)]
 mod tests {
-
-	use super::Regex;
-	use super::Revisioned;
+	use super::*;
 
 	#[test]
 	fn test_regex() {
@@ -34,7 +36,7 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 23);
-		let out = <Regex as Revisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out = <Regex as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val.as_str(), out.as_str());
 	}
 }

--- a/src/implementations/regex.rs
+++ b/src/implementations/regex.rs
@@ -21,6 +21,7 @@ impl DeserializeRevisioned for Regex {
 }
 
 impl Revisioned for Regex {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}

--- a/src/implementations/result.rs
+++ b/src/implementations/result.rs
@@ -35,6 +35,7 @@ impl<E: DeserializeRevisioned, T: DeserializeRevisioned> DeserializeRevisioned f
 }
 
 impl<E: Revisioned, T: Revisioned> Revisioned for Result<T, E> {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}

--- a/src/implementations/result.rs
+++ b/src/implementations/result.rs
@@ -1,7 +1,10 @@
+use crate::DeserializeRevisioned;
+use crate::SerializeRevisioned;
+
 use super::super::Error;
 use super::super::Revisioned;
 
-impl<E: Revisioned, T: Revisioned> Revisioned for Result<T, E> {
+impl<E: SerializeRevisioned, T: SerializeRevisioned> SerializeRevisioned for Result<T, E> {
 	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		match self {
@@ -15,7 +18,9 @@ impl<E: Revisioned, T: Revisioned> Revisioned for Result<T, E> {
 			}
 		}
 	}
+}
 
+impl<E: DeserializeRevisioned, T: DeserializeRevisioned> DeserializeRevisioned for Result<T, E> {
 	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
 		let variant = u32::deserialize_revisioned(reader)?;
@@ -27,7 +32,9 @@ impl<E: Revisioned, T: Revisioned> Revisioned for Result<T, E> {
 			_ => Err(Error::Deserialize("Unknown variant index".to_string())),
 		}
 	}
+}
 
+impl<E: Revisioned, T: Revisioned> Revisioned for Result<T, E> {
 	fn revision() -> u16 {
 		1
 	}
@@ -36,7 +43,7 @@ impl<E: Revisioned, T: Revisioned> Revisioned for Result<T, E> {
 #[cfg(test)]
 mod tests {
 
-	use super::Revisioned;
+	use super::*;
 
 	#[test]
 	fn test_result_ok() {
@@ -44,7 +51,7 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 2);
-		let out = <Result<bool, String> as Revisioned>::deserialize_revisioned(&mut mem.as_slice())
+		let out = <Result<bool, String> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
 			.unwrap();
 		assert_eq!(val, out);
 	}
@@ -55,7 +62,7 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 12);
-		let out = <Result<bool, String> as Revisioned>::deserialize_revisioned(&mut mem.as_slice())
+		let out = <Result<bool, String> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
 			.unwrap();
 		assert_eq!(val, out);
 	}

--- a/src/implementations/result.rs
+++ b/src/implementations/result.rs
@@ -51,8 +51,10 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 2);
-		let out = <Result<bool, String> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
-			.unwrap();
+		let out = <Result<bool, String> as DeserializeRevisioned>::deserialize_revisioned(
+			&mut mem.as_slice(),
+		)
+		.unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -62,8 +64,10 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 12);
-		let out = <Result<bool, String> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
-			.unwrap();
+		let out = <Result<bool, String> as DeserializeRevisioned>::deserialize_revisioned(
+			&mut mem.as_slice(),
+		)
+		.unwrap();
 		assert_eq!(val, out);
 	}
 }

--- a/src/implementations/reverse.rs
+++ b/src/implementations/reverse.rs
@@ -1,21 +1,34 @@
+use crate::DeserializeRevisioned;
+use crate::SerializeRevisioned;
+
 use super::super::Error;
 use super::super::Revisioned;
 use std::cmp::Reverse;
 
-impl<T> Revisioned for Reverse<T>
+impl<T> SerializeRevisioned for Reverse<T>
 where
-	T: Revisioned,
+	T: SerializeRevisioned,
 {
 	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		self.0.serialize_revisioned(writer)
 	}
+}
 
+impl<T> DeserializeRevisioned for Reverse<T>
+where
+	T: DeserializeRevisioned,
+{
 	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
 		Ok(Reverse(T::deserialize_revisioned(reader)?))
 	}
+}
 
+impl<T> Revisioned for Reverse<T>
+where
+	T: Revisioned,
+{
 	fn revision() -> u16 {
 		1
 	}
@@ -24,8 +37,7 @@ where
 #[cfg(test)]
 mod tests {
 
-	use super::Revisioned;
-	use std::cmp::Reverse;
+	use super::*;
 
 	#[test]
 	fn test_reverse() {
@@ -34,7 +46,7 @@ mod tests {
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 5);
 		let out =
-			<Reverse<u32> as Revisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+			<Reverse<u32> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 }

--- a/src/implementations/reverse.rs
+++ b/src/implementations/reverse.rs
@@ -29,6 +29,7 @@ impl<T> Revisioned for Reverse<T>
 where
 	T: Revisioned,
 {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}

--- a/src/implementations/reverse.rs
+++ b/src/implementations/reverse.rs
@@ -46,7 +46,8 @@ mod tests {
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 5);
 		let out =
-			<Reverse<u32> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+			<Reverse<u32> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
+				.unwrap();
 		assert_eq!(val, out);
 	}
 }

--- a/src/implementations/roaring.rs
+++ b/src/implementations/roaring.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "roaring")]
 
 use super::super::Error;
-use super::super::{Revisioned, DeserializeRevisioned, SerializeRevisioned};
+use super::super::{DeserializeRevisioned, Revisioned, SerializeRevisioned};
 use roaring::{RoaringBitmap, RoaringTreemap};
 
 impl SerializeRevisioned for RoaringTreemap {
@@ -55,7 +55,8 @@ mod tests {
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 8);
 		let out =
-			<RoaringTreemap as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+			<RoaringTreemap as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
+				.unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -66,7 +67,8 @@ mod tests {
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 8);
 		let out =
-			<RoaringBitmap as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+			<RoaringBitmap as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
+				.unwrap();
 		assert_eq!(val, out);
 	}
 }

--- a/src/implementations/roaring.rs
+++ b/src/implementations/roaring.rs
@@ -19,6 +19,7 @@ impl DeserializeRevisioned for RoaringTreemap {
 }
 
 impl Revisioned for RoaringTreemap {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}
@@ -39,6 +40,7 @@ impl DeserializeRevisioned for RoaringBitmap {
 }
 
 impl Revisioned for RoaringBitmap {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}

--- a/src/implementations/roaring.rs
+++ b/src/implementations/roaring.rs
@@ -1,36 +1,44 @@
 #![cfg(feature = "roaring")]
 
 use super::super::Error;
-use super::super::Revisioned;
+use super::super::{Revisioned, DeserializeRevisioned, SerializeRevisioned};
 use roaring::{RoaringBitmap, RoaringTreemap};
 
-impl Revisioned for RoaringTreemap {
+impl SerializeRevisioned for RoaringTreemap {
 	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		self.serialize_into(writer).map_err(|ref err| Error::Serialize(format!("{:?}", err)))
 	}
+}
 
+impl DeserializeRevisioned for RoaringTreemap {
 	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
 		Self::deserialize_from(reader).map_err(|ref err| Error::Deserialize(format!("{:?}", err)))
 	}
+}
 
+impl Revisioned for RoaringTreemap {
 	fn revision() -> u16 {
 		1
 	}
 }
 
-impl Revisioned for RoaringBitmap {
+impl SerializeRevisioned for RoaringBitmap {
 	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		self.serialize_into(writer).map_err(|ref err| Error::Serialize(format!("{:?}", err)))
 	}
+}
 
+impl DeserializeRevisioned for RoaringBitmap {
 	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
 		Self::deserialize_from(reader).map_err(|ref err| Error::Deserialize(format!("{:?}", err)))
 	}
+}
 
+impl Revisioned for RoaringBitmap {
 	fn revision() -> u16 {
 		1
 	}
@@ -38,8 +46,7 @@ impl Revisioned for RoaringBitmap {
 
 #[cfg(test)]
 mod tests {
-	use super::Revisioned;
-	use roaring::{RoaringBitmap, RoaringTreemap};
+	use super::*;
 
 	#[test]
 	fn test_roaring_treemap() {
@@ -48,7 +55,7 @@ mod tests {
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 8);
 		let out =
-			<RoaringTreemap as Revisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+			<RoaringTreemap as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -59,7 +66,7 @@ mod tests {
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 8);
 		let out =
-			<RoaringBitmap as Revisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+			<RoaringBitmap as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 }

--- a/src/implementations/string.rs
+++ b/src/implementations/string.rs
@@ -28,17 +28,17 @@ impl Revisioned for String {
 
 impl SerializeRevisioned for char {
 	#[inline]
-	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
-		let mut buffer = [0u8; 4];
-		writer.write_all(self.encode_utf8(&mut buffer).as_bytes()).map_err(Error::Io)
+	fn serialize_revisioned<W: std::io::Write>(&self, w: &mut W) -> Result<(), Error> {
+		let buffer = &mut [0u8; 4];
+		w.write_all(self.encode_utf8(buffer).as_bytes()).map_err(Error::Io)
 	}
 }
 
 impl DeserializeRevisioned for char {
 	#[inline]
-	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
+	fn deserialize_revisioned<R: std::io::Read>(r: &mut R) -> Result<Self, Error> {
 		let mut buffer = [0u8; 4];
-		reader.read_exact(&mut buffer[..1]).map_err(Error::Io)?;
+		r.read_exact(&mut buffer[..1]).map_err(Error::Io)?;
 
 		let len = CHAR_LENGTH[buffer[0] as usize];
 
@@ -46,7 +46,7 @@ impl DeserializeRevisioned for char {
 			return Err(Error::InvalidCharEncoding);
 		}
 
-		reader.read_exact(&mut buffer[1..(len as usize)]).map_err(Error::Io)?;
+		r.read_exact(&mut buffer[1..(len as usize)]).map_err(Error::Io)?;
 
 		str::from_utf8(&buffer[..(len as usize)])
 			.map_err(|_| Error::InvalidCharEncoding)

--- a/src/implementations/string.rs
+++ b/src/implementations/string.rs
@@ -92,7 +92,8 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 15);
-		let out = <String as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out =
+			<String as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 

--- a/src/implementations/string.rs
+++ b/src/implementations/string.rs
@@ -20,6 +20,7 @@ impl DeserializeRevisioned for String {
 }
 
 impl Revisioned for String {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}
@@ -54,6 +55,7 @@ impl DeserializeRevisioned for char {
 }
 
 impl Revisioned for char {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}

--- a/src/implementations/trees.rs
+++ b/src/implementations/trees.rs
@@ -1,5 +1,5 @@
 use super::super::Error;
-use super::super::{Revisioned, SerializeRevisioned, DeserializeRevisioned};
+use super::super::{DeserializeRevisioned, Revisioned, SerializeRevisioned};
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::collections::BinaryHeap;
@@ -46,9 +46,7 @@ impl<K: Revisioned + Eq + Hash, V: Revisioned, S: BuildHasher + Default> Revisio
 	}
 }
 
-impl<K: SerializeRevisioned + Ord, V: SerializeRevisioned> SerializeRevisioned
-	for BTreeMap<K, V>
-{
+impl<K: SerializeRevisioned + Ord, V: SerializeRevisioned> SerializeRevisioned for BTreeMap<K, V> {
 	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		self.len().serialize_revisioned(writer)?;
@@ -185,9 +183,10 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 61);
-		let out =
-			<HashMap<String, Vec<f64>> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
-				.unwrap();
+		let out = <HashMap<String, Vec<f64>> as DeserializeRevisioned>::deserialize_revisioned(
+			&mut mem.as_slice(),
+		)
+		.unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -199,9 +198,10 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 61);
-		let out =
-			<BTreeMap<String, Vec<f64>> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
-				.unwrap();
+		let out = <BTreeMap<String, Vec<f64>> as DeserializeRevisioned>::deserialize_revisioned(
+			&mut mem.as_slice(),
+		)
+		.unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -214,7 +214,8 @@ mod tests {
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 11);
 		let out =
-			<HashSet<String> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+			<HashSet<String> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
+				.unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -226,8 +227,10 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 11);
-		let out =
-			<BTreeSet<String> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out = <BTreeSet<String> as DeserializeRevisioned>::deserialize_revisioned(
+			&mut mem.as_slice(),
+		)
+		.unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -239,8 +242,10 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 11);
-		let out = <BinaryHeap<String> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
-			.unwrap();
+		let out = <BinaryHeap<String> as DeserializeRevisioned>::deserialize_revisioned(
+			&mut mem.as_slice(),
+		)
+		.unwrap();
 		assert_eq!(val.into_sorted_vec(), out.into_sorted_vec());
 	}
 }

--- a/src/implementations/trees.rs
+++ b/src/implementations/trees.rs
@@ -41,6 +41,7 @@ impl<K: DeserializeRevisioned + Eq + Hash, V: DeserializeRevisioned> Deserialize
 impl<K: Revisioned + Eq + Hash, V: Revisioned, S: BuildHasher + Default> Revisioned
 	for HashMap<K, V, S>
 {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}
@@ -75,6 +76,7 @@ impl<K: DeserializeRevisioned + Ord, V: DeserializeRevisioned> DeserializeRevisi
 }
 
 impl<K: Revisioned + Ord, V: Revisioned> Revisioned for BTreeMap<K, V> {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}
@@ -105,6 +107,7 @@ impl<T: DeserializeRevisioned + Eq + Hash> DeserializeRevisioned for HashSet<T> 
 }
 
 impl<T: Revisioned + Eq + Hash, S: BuildHasher + Default> Revisioned for HashSet<T, S> {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}
@@ -135,6 +138,7 @@ impl<T: DeserializeRevisioned + Ord> DeserializeRevisioned for BTreeSet<T> {
 }
 
 impl<T: Revisioned + Eq + Ord> Revisioned for BTreeSet<T> {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}
@@ -165,6 +169,7 @@ impl<T: DeserializeRevisioned + Ord> DeserializeRevisioned for BinaryHeap<T> {
 }
 
 impl<T: Revisioned + Ord> Revisioned for BinaryHeap<T> {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}

--- a/src/implementations/trees.rs
+++ b/src/implementations/trees.rs
@@ -22,13 +22,13 @@ impl<K: SerializeRevisioned + Eq + Hash, V: SerializeRevisioned> SerializeRevisi
 	}
 }
 
-impl<K: DeserializeRevisioned + Eq + Hash, V: DeserializeRevisioned> DeserializeRevisioned
-	for HashMap<K, V>
+impl<K: DeserializeRevisioned + Eq + Hash, V: DeserializeRevisioned, S: BuildHasher + Default>
+	DeserializeRevisioned for HashMap<K, V, S>
 {
 	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
 		let len = usize::deserialize_revisioned(reader)?;
-		let mut map = Self::with_capacity(len);
+		let mut map = Self::with_capacity_and_hasher(len, S::default());
 		for _ in 0..len {
 			let k = K::deserialize_revisioned(reader)?;
 			let v = V::deserialize_revisioned(reader)?;
@@ -82,7 +82,9 @@ impl<K: Revisioned + Ord, V: Revisioned> Revisioned for BTreeMap<K, V> {
 	}
 }
 
-impl<T: SerializeRevisioned + Eq + Hash> SerializeRevisioned for HashSet<T> {
+impl<T: SerializeRevisioned + Eq + Hash, S: BuildHasher + Default> SerializeRevisioned
+	for HashSet<T, S>
+{
 	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		self.len().serialize_revisioned(writer)?;
@@ -93,11 +95,13 @@ impl<T: SerializeRevisioned + Eq + Hash> SerializeRevisioned for HashSet<T> {
 	}
 }
 
-impl<T: DeserializeRevisioned + Eq + Hash> DeserializeRevisioned for HashSet<T> {
+impl<T: DeserializeRevisioned + Eq + Hash, S: BuildHasher + Default> DeserializeRevisioned
+	for HashSet<T, S>
+{
 	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
 		let len = usize::deserialize_revisioned(reader)?;
-		let mut set = Self::with_capacity(len);
+		let mut set = Self::with_capacity_and_hasher(len, S::default());
 		for _ in 0..len {
 			let v = T::deserialize_revisioned(reader)?;
 			set.insert(v);

--- a/src/implementations/trees.rs
+++ b/src/implementations/trees.rs
@@ -1,5 +1,5 @@
 use super::super::Error;
-use super::super::Revisioned;
+use super::super::{Revisioned, SerializeRevisioned, DeserializeRevisioned};
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::collections::BinaryHeap;
@@ -8,8 +8,8 @@ use std::collections::HashSet;
 use std::hash::BuildHasher;
 use std::hash::Hash;
 
-impl<K: Revisioned + Eq + Hash, V: Revisioned, S: BuildHasher + Default> Revisioned
-	for HashMap<K, V, S>
+impl<K: SerializeRevisioned + Eq + Hash, V: SerializeRevisioned> SerializeRevisioned
+	for HashMap<K, V>
 {
 	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
@@ -20,11 +20,15 @@ impl<K: Revisioned + Eq + Hash, V: Revisioned, S: BuildHasher + Default> Revisio
 		}
 		Ok(())
 	}
+}
 
+impl<K: DeserializeRevisioned + Eq + Hash, V: DeserializeRevisioned> DeserializeRevisioned
+	for HashMap<K, V>
+{
 	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
 		let len = usize::deserialize_revisioned(reader)?;
-		let mut map = Self::with_capacity_and_hasher(len, S::default());
+		let mut map = Self::with_capacity(len);
 		for _ in 0..len {
 			let k = K::deserialize_revisioned(reader)?;
 			let v = V::deserialize_revisioned(reader)?;
@@ -32,13 +36,19 @@ impl<K: Revisioned + Eq + Hash, V: Revisioned, S: BuildHasher + Default> Revisio
 		}
 		Ok(map)
 	}
+}
 
+impl<K: Revisioned + Eq + Hash, V: Revisioned, S: BuildHasher + Default> Revisioned
+	for HashMap<K, V, S>
+{
 	fn revision() -> u16 {
 		1
 	}
 }
 
-impl<K: Revisioned + Ord, V: Revisioned> Revisioned for BTreeMap<K, V> {
+impl<K: SerializeRevisioned + Ord, V: SerializeRevisioned> SerializeRevisioned
+	for BTreeMap<K, V>
+{
 	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		self.len().serialize_revisioned(writer)?;
@@ -48,11 +58,15 @@ impl<K: Revisioned + Ord, V: Revisioned> Revisioned for BTreeMap<K, V> {
 		}
 		Ok(())
 	}
+}
 
+impl<K: DeserializeRevisioned + Ord, V: DeserializeRevisioned> DeserializeRevisioned
+	for BTreeMap<K, V>
+{
 	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
 		let len = usize::deserialize_revisioned(reader)?;
-		let mut map = BTreeMap::new();
+		let mut map = Self::new();
 		for _ in 0..len {
 			let k = K::deserialize_revisioned(reader)?;
 			let v = V::deserialize_revisioned(reader)?;
@@ -60,13 +74,15 @@ impl<K: Revisioned + Ord, V: Revisioned> Revisioned for BTreeMap<K, V> {
 		}
 		Ok(map)
 	}
+}
 
+impl<K: Revisioned + Ord, V: Revisioned> Revisioned for BTreeMap<K, V> {
 	fn revision() -> u16 {
 		1
 	}
 }
 
-impl<T: Revisioned + Eq + Hash, S: BuildHasher + Default> Revisioned for HashSet<T, S> {
+impl<T: SerializeRevisioned + Eq + Hash> SerializeRevisioned for HashSet<T> {
 	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		self.len().serialize_revisioned(writer)?;
@@ -75,24 +91,28 @@ impl<T: Revisioned + Eq + Hash, S: BuildHasher + Default> Revisioned for HashSet
 		}
 		Ok(())
 	}
+}
 
+impl<T: DeserializeRevisioned + Eq + Hash> DeserializeRevisioned for HashSet<T> {
 	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
 		let len = usize::deserialize_revisioned(reader)?;
-		let mut set = Self::with_capacity_and_hasher(len, S::default());
+		let mut set = Self::with_capacity(len);
 		for _ in 0..len {
 			let v = T::deserialize_revisioned(reader)?;
 			set.insert(v);
 		}
 		Ok(set)
 	}
+}
 
+impl<T: Revisioned + Eq + Hash, S: BuildHasher + Default> Revisioned for HashSet<T, S> {
 	fn revision() -> u16 {
 		1
 	}
 }
 
-impl<T: Revisioned + Eq + Ord> Revisioned for BTreeSet<T> {
+impl<T: SerializeRevisioned + Ord> SerializeRevisioned for BTreeSet<T> {
 	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		self.len().serialize_revisioned(writer)?;
@@ -101,7 +121,9 @@ impl<T: Revisioned + Eq + Ord> Revisioned for BTreeSet<T> {
 		}
 		Ok(())
 	}
+}
 
+impl<T: DeserializeRevisioned + Ord> DeserializeRevisioned for BTreeSet<T> {
 	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
 		let len = usize::deserialize_revisioned(reader)?;
@@ -112,13 +134,15 @@ impl<T: Revisioned + Eq + Ord> Revisioned for BTreeSet<T> {
 		}
 		Ok(set)
 	}
+}
 
+impl<T: Revisioned + Eq + Ord> Revisioned for BTreeSet<T> {
 	fn revision() -> u16 {
 		1
 	}
 }
 
-impl<T: Revisioned + Ord> Revisioned for BinaryHeap<T> {
+impl<T: SerializeRevisioned + Ord> SerializeRevisioned for BinaryHeap<T> {
 	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		self.len().serialize_revisioned(writer)?;
@@ -127,18 +151,22 @@ impl<T: Revisioned + Ord> Revisioned for BinaryHeap<T> {
 		}
 		Ok(())
 	}
+}
 
+impl<T: DeserializeRevisioned + Ord> DeserializeRevisioned for BinaryHeap<T> {
 	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
 		let len = usize::deserialize_revisioned(reader)?;
-		let mut heap = BinaryHeap::with_capacity(len);
+		let mut heap = Self::with_capacity(len);
 		for _ in 0..len {
 			let v = T::deserialize_revisioned(reader)?;
 			heap.push(v);
 		}
 		Ok(heap)
 	}
+}
 
+impl<T: Revisioned + Ord> Revisioned for BinaryHeap<T> {
 	fn revision() -> u16 {
 		1
 	}
@@ -147,12 +175,7 @@ impl<T: Revisioned + Ord> Revisioned for BinaryHeap<T> {
 #[cfg(test)]
 mod tests {
 
-	use super::BTreeMap;
-	use super::BTreeSet;
-	use super::BinaryHeap;
-	use super::HashMap;
-	use super::HashSet;
-	use super::Revisioned;
+	use super::*;
 
 	#[test]
 	fn test_hashmap() {
@@ -163,7 +186,7 @@ mod tests {
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 61);
 		let out =
-			<HashMap<String, Vec<f64>> as Revisioned>::deserialize_revisioned(&mut mem.as_slice())
+			<HashMap<String, Vec<f64>> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
 				.unwrap();
 		assert_eq!(val, out);
 	}
@@ -177,7 +200,7 @@ mod tests {
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 61);
 		let out =
-			<BTreeMap<String, Vec<f64>> as Revisioned>::deserialize_revisioned(&mut mem.as_slice())
+			<BTreeMap<String, Vec<f64>> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
 				.unwrap();
 		assert_eq!(val, out);
 	}
@@ -191,7 +214,7 @@ mod tests {
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 11);
 		let out =
-			<HashSet<String> as Revisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+			<HashSet<String> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -204,7 +227,7 @@ mod tests {
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 11);
 		let out =
-			<BTreeSet<String> as Revisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+			<BTreeSet<String> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -216,7 +239,7 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 11);
-		let out = <BinaryHeap<String> as Revisioned>::deserialize_revisioned(&mut mem.as_slice())
+		let out = <BinaryHeap<String> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
 			.unwrap();
 		assert_eq!(val.into_sorted_vec(), out.into_sorted_vec());
 	}

--- a/src/implementations/tuple.rs
+++ b/src/implementations/tuple.rs
@@ -1,5 +1,5 @@
 use super::super::Error;
-use super::super::Revisioned;
+use super::super::{Revisioned, SerializeRevisioned, DeserializeRevisioned};
 
 macro_rules! impl_tuple {
 	($($n:ident),*$(,)?) => {
@@ -7,13 +7,9 @@ macro_rules! impl_tuple {
 	};
 
 	($($n:ident,)* @marker $head:ident, $($tail:ident,)*) => {
-		impl<$($n),*> Revisioned for ($($n,)*)
-			where $($n: Revisioned),*
+		impl<$($n),*> SerializeRevisioned for ($($n,)*)
+			where $($n: SerializeRevisioned),*
 		{
-			fn revision() -> u16{
-				1
-			}
-
 			#[inline]
 			#[allow(non_snake_case)]
 			fn serialize_revisioned<W: std::io::Write>(&self, _writer: &mut W) -> Result<(), Error> {
@@ -23,14 +19,26 @@ macro_rules! impl_tuple {
 				)*
 				Ok(())
 			}
+		}
 
+		impl<$($n),*> DeserializeRevisioned for ($($n,)*)
+			where $($n: DeserializeRevisioned),*
+		{
 			#[inline]
 			#[allow(non_snake_case)]
 			fn deserialize_revisioned<R: std::io::Read>(_reader: &mut R) -> Result<Self, Error> {
 				$(
-					let $n = Revisioned::deserialize_revisioned(_reader)?;
+					let $n = DeserializeRevisioned::deserialize_revisioned(_reader)?;
 				)*
 				Ok(($($n,)*))
+			}
+		}
+
+		impl<$($n),*> Revisioned for ($($n,)*)
+			where $($n: Revisioned),*
+		{
+			fn revision() -> u16{
+				1
 			}
 		}
 
@@ -38,30 +46,38 @@ macro_rules! impl_tuple {
 
 	};
 	($($n:ident,)* @marker) => {
-		impl<$($n),*> Revisioned for ($($n),*)
-			where $($n: Revisioned),*
+		impl<$($n),*> SerializeRevisioned for ($($n),*)
+			where $($n: SerializeRevisioned),*
 		{
-			fn revision() -> u16{
-				1
-			}
-
 			#[inline]
 			#[allow(non_snake_case)]
 			fn serialize_revisioned<W: std::io::Write>(&self, _writer: &mut W) -> Result<(), Error> {
-				let ($(ref $n),*) = self;
+				let ($(ref $n),*) = *self;
 				$(
 					$n.serialize_revisioned(_writer)?;
 				)*
 				Ok(())
 			}
+		}
 
+		impl<$($n),*> DeserializeRevisioned for ($($n),*)
+			where $($n: DeserializeRevisioned),*
+		{
 			#[inline]
 			#[allow(non_snake_case)]
 			fn deserialize_revisioned<R: std::io::Read>(_reader: &mut R) -> Result<Self, Error> {
 				$(
-					let $n = Revisioned::deserialize_revisioned(_reader)?;
+					let $n = DeserializeRevisioned::deserialize_revisioned(_reader)?;
 				)*
 				Ok(($($n),*))
+			}
+		}
+
+		impl<$($n),*> Revisioned for ($($n),*)
+			where $($n: Revisioned),*
+		{
+			fn revision() -> u16{
+				1
 			}
 		}
 	};
@@ -74,7 +90,7 @@ mod tests {
 
 	use crate::implementations::assert_bincode_compat;
 
-	use super::Revisioned;
+	use super::*;
 
 	#[test]
 	fn test_tuple_2() {
@@ -84,7 +100,7 @@ mod tests {
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 6);
 		let out =
-			<(String, bool) as Revisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+			<(String, bool) as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -95,7 +111,7 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 14);
-		let out = <(String, bool, f64) as Revisioned>::deserialize_revisioned(&mut mem.as_slice())
+		let out = <(String, bool, f64) as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
 			.unwrap();
 		assert_eq!(val, out);
 	}
@@ -107,7 +123,7 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 16);
-		let out = <(String, bool, f64, Option<char>) as Revisioned>::deserialize_revisioned(
+		let out = <(String, bool, f64, Option<char>) as DeserializeRevisioned>::deserialize_revisioned(
 			&mut mem.as_slice(),
 		)
 		.unwrap();
@@ -128,7 +144,7 @@ mod tests {
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 20);
 		let out =
-			<(String, bool, f64, Option<char>, Vec<u8>) as Revisioned>::deserialize_revisioned(
+			<(String, bool, f64, Option<char>, Vec<u8>) as DeserializeRevisioned>::deserialize_revisioned(
 				&mut mem.as_slice(),
 			)
 			.unwrap();

--- a/src/implementations/tuple.rs
+++ b/src/implementations/tuple.rs
@@ -1,5 +1,5 @@
 use super::super::Error;
-use super::super::{Revisioned, SerializeRevisioned, DeserializeRevisioned};
+use super::super::{DeserializeRevisioned, Revisioned, SerializeRevisioned};
 
 macro_rules! impl_tuple {
 	($($n:ident),*$(,)?) => {
@@ -100,7 +100,8 @@ mod tests {
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 6);
 		let out =
-			<(String, bool) as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+			<(String, bool) as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
+				.unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -111,8 +112,10 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 14);
-		let out = <(String, bool, f64) as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
-			.unwrap();
+		let out = <(String, bool, f64) as DeserializeRevisioned>::deserialize_revisioned(
+			&mut mem.as_slice(),
+		)
+		.unwrap();
 		assert_eq!(val, out);
 	}
 
@@ -123,10 +126,11 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 16);
-		let out = <(String, bool, f64, Option<char>) as DeserializeRevisioned>::deserialize_revisioned(
-			&mut mem.as_slice(),
-		)
-		.unwrap();
+		let out =
+			<(String, bool, f64, Option<char>) as DeserializeRevisioned>::deserialize_revisioned(
+				&mut mem.as_slice(),
+			)
+			.unwrap();
 		assert_eq!(val, out);
 	}
 

--- a/src/implementations/tuple.rs
+++ b/src/implementations/tuple.rs
@@ -53,7 +53,7 @@ macro_rules! impl_tuple {
 			#[inline]
 			#[allow(non_snake_case)]
 			fn serialize_revisioned<W: std::io::Write>(&self, _writer: &mut W) -> Result<(), Error> {
-				let ($(ref $n),*) = *self;
+				let ($(ref $n),*) = self;
 				$(
 					$n.serialize_revisioned(_writer)?;
 				)*

--- a/src/implementations/tuple.rs
+++ b/src/implementations/tuple.rs
@@ -37,6 +37,7 @@ macro_rules! impl_tuple {
 		impl<$($n),*> Revisioned for ($($n,)*)
 			where $($n: Revisioned),*
 		{
+			#[inline]
 			fn revision() -> u16{
 				1
 			}
@@ -76,6 +77,7 @@ macro_rules! impl_tuple {
 		impl<$($n),*> Revisioned for ($($n),*)
 			where $($n: Revisioned),*
 		{
+			#[inline]
 			fn revision() -> u16{
 				1
 			}

--- a/src/implementations/uuid.rs
+++ b/src/implementations/uuid.rs
@@ -1,22 +1,26 @@
 #![cfg(feature = "uuid")]
 
 use super::super::Error;
-use super::super::Revisioned;
+use super::super::{Revisioned, DeserializeRevisioned, SerializeRevisioned};
 use uuid::Uuid;
 
-impl Revisioned for Uuid {
+impl SerializeRevisioned for Uuid {
 	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		writer.write_all(self.as_bytes()).map_err(Error::Io)
 	}
+}
 
+impl DeserializeRevisioned for Uuid {
 	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
 		let mut v = [0u8; 16];
 		reader.read_exact(&mut v).map_err(Error::Io)?;
 		Uuid::from_slice(&v).map_err(|_| Error::Deserialize("invalid uuid".to_string()))
 	}
+}
 
+impl Revisioned for Uuid {
 	fn revision() -> u16 {
 		1
 	}
@@ -25,8 +29,7 @@ impl Revisioned for Uuid {
 #[cfg(test)]
 mod tests {
 
-	use super::Revisioned;
-	use super::Uuid;
+	use super::*;
 
 	#[test]
 	fn test_uuid() {
@@ -38,7 +41,7 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 16);
-		let out = <Uuid as Revisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out = <Uuid as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 }

--- a/src/implementations/uuid.rs
+++ b/src/implementations/uuid.rs
@@ -21,6 +21,7 @@ impl DeserializeRevisioned for Uuid {
 }
 
 impl Revisioned for Uuid {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}

--- a/src/implementations/uuid.rs
+++ b/src/implementations/uuid.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "uuid")]
 
 use super::super::Error;
-use super::super::{Revisioned, DeserializeRevisioned, SerializeRevisioned};
+use super::super::{DeserializeRevisioned, Revisioned, SerializeRevisioned};
 use uuid::Uuid;
 
 impl SerializeRevisioned for Uuid {
@@ -41,7 +41,8 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 16);
-		let out = <Uuid as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out =
+			<Uuid as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 }

--- a/src/implementations/vecs.rs
+++ b/src/implementations/vecs.rs
@@ -63,7 +63,9 @@ mod tests {
 		let mut mem: Vec<u8> = vec![];
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 16);
-		let out = <Vec<String> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		let out =
+			<Vec<String> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
+				.unwrap();
 		assert_eq!(val, out);
 	}
 }

--- a/src/implementations/vecs.rs
+++ b/src/implementations/vecs.rs
@@ -46,6 +46,7 @@ impl<T> Revisioned for Vec<T>
 where
 	T: Revisioned,
 {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}

--- a/src/implementations/wrapping.rs
+++ b/src/implementations/wrapping.rs
@@ -1,21 +1,34 @@
+use crate::DeserializeRevisioned;
+use crate::SerializeRevisioned;
+
 use super::super::Error;
 use super::super::Revisioned;
 use std::num::Wrapping;
 
-impl<T> Revisioned for Wrapping<T>
+impl<T> SerializeRevisioned for Wrapping<T>
 where
-	T: Revisioned,
+	T: SerializeRevisioned,
 {
 	#[inline]
 	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
 		self.0.serialize_revisioned(writer)
 	}
+}
 
+impl<T> DeserializeRevisioned for Wrapping<T>
+where
+	T: DeserializeRevisioned,
+{
 	#[inline]
 	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
 		Ok(Wrapping(T::deserialize_revisioned(reader)?))
 	}
+}
 
+impl<T> Revisioned for Wrapping<T>
+where
+	T: Revisioned,
+{
 	fn revision() -> u16 {
 		1
 	}
@@ -24,8 +37,7 @@ where
 #[cfg(test)]
 mod tests {
 
-	use super::Revisioned;
-	use std::num::Wrapping;
+	use super::*;
 
 	#[test]
 	fn test_wrapping() {
@@ -34,7 +46,7 @@ mod tests {
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 5);
 		let out =
-			<Wrapping<u32> as Revisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+			<Wrapping<u32> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
 		assert_eq!(val, out);
 	}
 }

--- a/src/implementations/wrapping.rs
+++ b/src/implementations/wrapping.rs
@@ -46,7 +46,8 @@ mod tests {
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 5);
 		let out =
-			<Wrapping<u32> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+			<Wrapping<u32> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
+				.unwrap();
 		assert_eq!(val, out);
 	}
 }

--- a/src/implementations/wrapping.rs
+++ b/src/implementations/wrapping.rs
@@ -29,6 +29,7 @@ impl<T> Revisioned for Wrapping<T>
 where
 	T: Revisioned,
 {
+	#[inline]
 	fn revision() -> u16 {
 		1
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ pub mod prelude {
 /// 	  self.0.serialize_revisioned(writer)
 ///   }
 /// }
-/// 
+///
 /// impl<T> DeserializeRevisioned for MyType<T>
 /// where
 ///    T: DeserializeRevisioned,
@@ -50,7 +50,7 @@ pub mod prelude {
 /// 	  Ok(MyType(T::deserialize_revisioned(reader)?))
 ///   }
 /// }
-/// 
+///
 /// impl<T> Revisioned for MyType<T>
 /// where
 ///     T: Revisioned,
@@ -79,7 +79,9 @@ pub trait SerializeRevisioned {
 
 pub trait DeserializeRevisioned {
 	/// Deserializes a new instance of the struct from the specficifed `reader`.
-	fn deserialize_revisioned<R: Read>(r: &mut R) -> Result<Self, Error> where Self: Sized;
+	fn deserialize_revisioned<R: Read>(r: &mut R) -> Result<Self, Error>
+	where
+		Self: Sized;
 }
 
 /// Deserialize a revisioned type from a reader

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ use std::any::TypeId;
 use std::io::{Read, Write};
 
 pub mod prelude {
-	pub use super::{DeserializeRevisioned, Revisioned, SerializeRevisioned};
+	pub use crate::{revisioned, DeserializeRevisioned, Revisioned, SerializeRevisioned};
 }
 
 /// Trait that provides an interface for version aware serialization and deserialization.
@@ -37,7 +37,7 @@ pub mod prelude {
 /// {
 ///    #[inline]
 ///   fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
-/// 	  self.0.serialize_revisioned(writer)
+///       self.0.serialize_revisioned(writer)
 ///   }
 /// }
 ///
@@ -47,7 +47,7 @@ pub mod prelude {
 /// {
 ///   #[inline]
 ///   fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
-/// 	  Ok(MyType(T::deserialize_revisioned(reader)?))
+///       Ok(MyType(T::deserialize_revisioned(reader)?))
 ///   }
 /// }
 ///
@@ -64,6 +64,7 @@ pub trait Revisioned {
 	/// Returns the current revision of this type.
 	fn revision() -> u16;
 	/// Returns the type id of this type.
+	#[inline]
 	fn type_id() -> std::any::TypeId
 	where
 		Self: 'static,
@@ -85,6 +86,7 @@ pub trait DeserializeRevisioned {
 }
 
 /// Deserialize a revisioned type from a reader
+#[inline]
 pub fn from_reader<R, T>(rdr: &mut R) -> Result<T, Error>
 where
 	R: Read,
@@ -94,6 +96,7 @@ where
 }
 
 /// Deserialize a revisioned type from a slice of bytes
+#[inline]
 pub fn from_slice<T>(mut bytes: &[u8]) -> Result<T, Error>
 where
 	T: DeserializeRevisioned,
@@ -102,6 +105,7 @@ where
 }
 
 /// Serialize a revisioned type into a vec of bytes
+#[inline]
 pub fn to_writer<W, T>(writer: &mut W, t: &T) -> Result<(), Error>
 where
 	W: Write,
@@ -111,6 +115,7 @@ where
 }
 
 /// Serialize a revisioned type into a vec of bytes
+#[inline]
 pub fn to_vec<T>(t: &T) -> Result<Vec<u8>, Error>
 where
 	T: SerializeRevisioned,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,29 +18,43 @@ pub use derive::revisioned;
 use std::any::TypeId;
 use std::io::{Read, Write};
 
+pub mod prelude {
+	pub use super::{DeserializeRevisioned, Revisioned, SerializeRevisioned};
+}
+
 /// Trait that provides an interface for version aware serialization and deserialization.
 ///
 /// Example implementation
 /// ```
 /// use revision::Error;
-/// use revision::Revisioned;
+/// use revision::prelude::*;
 ///
 /// struct MyType<T>(T);
 ///
+/// impl<T> SerializeRevisioned for MyType<T>
+/// where
+///    T: SerializeRevisioned,
+/// {
+///    #[inline]
+///   fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
+/// 	  self.0.serialize_revisioned(writer)
+///   }
+/// }
+/// 
+/// impl<T> DeserializeRevisioned for MyType<T>
+/// where
+///    T: DeserializeRevisioned,
+/// {
+///   #[inline]
+///   fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
+/// 	  Ok(MyType(T::deserialize_revisioned(reader)?))
+///   }
+/// }
+/// 
 /// impl<T> Revisioned for MyType<T>
 /// where
 ///     T: Revisioned,
 /// {
-///     #[inline]
-///     fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
-///         self.0.serialize_revisioned(writer)
-///     }
-///
-///     #[inline]
-///     fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
-///         Ok(MyType(T::deserialize_revisioned(reader)?))
-///     }
-///
 ///     fn revision() -> u16 {
 ///         1
 ///     }
@@ -49,12 +63,6 @@ use std::io::{Read, Write};
 pub trait Revisioned {
 	/// Returns the current revision of this type.
 	fn revision() -> u16;
-	/// Serializes the struct using the specficifed `writer`.
-	fn serialize_revisioned<W: Write>(&self, w: &mut W) -> Result<(), Error>;
-	/// Deserializes a new instance of the struct from the specficifed `reader`.
-	fn deserialize_revisioned<R: Read>(r: &mut R) -> Result<Self, Error>
-	where
-		Self: Sized;
 	/// Returns the type id of this type.
 	fn type_id() -> std::any::TypeId
 	where
@@ -64,38 +72,48 @@ pub trait Revisioned {
 	}
 }
 
+pub trait SerializeRevisioned {
+	/// Serializes the struct using the specficifed `writer`.
+	fn serialize_revisioned<W: Write>(&self, w: &mut W) -> Result<(), Error>;
+}
+
+pub trait DeserializeRevisioned {
+	/// Deserializes a new instance of the struct from the specficifed `reader`.
+	fn deserialize_revisioned<R: Read>(r: &mut R) -> Result<Self, Error> where Self: Sized;
+}
+
 /// Deserialize a revisioned type from a reader
 pub fn from_reader<R, T>(rdr: &mut R) -> Result<T, Error>
 where
 	R: Read,
-	T: Revisioned,
+	T: DeserializeRevisioned,
 {
-	Revisioned::deserialize_revisioned(rdr)
+	DeserializeRevisioned::deserialize_revisioned(rdr)
 }
 
 /// Deserialize a revisioned type from a slice of bytes
 pub fn from_slice<T>(mut bytes: &[u8]) -> Result<T, Error>
 where
-	T: Revisioned,
+	T: DeserializeRevisioned,
 {
-	Revisioned::deserialize_revisioned(&mut bytes)
+	DeserializeRevisioned::deserialize_revisioned(&mut bytes)
 }
 
 /// Serialize a revisioned type into a vec of bytes
 pub fn to_writer<W, T>(writer: &mut W, t: &T) -> Result<(), Error>
 where
 	W: Write,
-	T: Revisioned,
+	T: SerializeRevisioned,
 {
-	Revisioned::serialize_revisioned(t, writer)
+	SerializeRevisioned::serialize_revisioned(t, writer)
 }
 
 /// Serialize a revisioned type into a vec of bytes
 pub fn to_vec<T>(t: &T) -> Result<Vec<u8>, Error>
 where
-	T: Revisioned,
+	T: SerializeRevisioned,
 {
 	let mut res = Vec::new();
-	Revisioned::serialize_revisioned(t, &mut res)?;
+	SerializeRevisioned::serialize_revisioned(t, &mut res)?;
 	Ok(res)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,12 +73,12 @@ pub trait Revisioned {
 	}
 }
 
-pub trait SerializeRevisioned {
+pub trait SerializeRevisioned: Revisioned {
 	/// Serializes the struct using the specficifed `writer`.
 	fn serialize_revisioned<W: Write>(&self, w: &mut W) -> Result<(), Error>;
 }
 
-pub trait DeserializeRevisioned {
+pub trait DeserializeRevisioned: Revisioned {
 	/// Deserializes a new instance of the struct from the specficifed `reader`.
 	fn deserialize_revisioned<R: Read>(r: &mut R) -> Result<Self, Error>
 	where

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -3,7 +3,7 @@
 
 use revision::revisioned;
 use revision::Error;
-use revision::{SerializeRevisioned, DeserializeRevisioned};
+use revision::{DeserializeRevisioned, SerializeRevisioned};
 use std::num::Wrapping;
 
 #[revisioned(revision = 3)]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -3,7 +3,7 @@
 
 use revision::revisioned;
 use revision::Error;
-use revision::Revisioned;
+use revision::{SerializeRevisioned, DeserializeRevisioned};
 use std::num::Wrapping;
 
 #[revisioned(revision = 3)]


### PR DESCRIPTION
As part of separating the structs, it will be extremely useful to ensure that old structs are not writeable, only readable. In order to facilitate this, we need to be able to separate out the serialization and deserialization traits which are currently baked into the `Revisioned` trait.

This change does the following:
* Separates `Revisioned` into three traits:
   * `SerializeRevisioned` which handles serialization.
   * `DeserializeRevisioned` which handles deserialization.
   * `Revisioned` which just contains `fn revision()` and `fn type_id()`.
* Adds the attributes `serialize` and `deserialize` to the `revision` proc macro. If they're set to false, then serialization or deserialization will be disabled respectively.

Additional minor changes contained in this PR:
* All public methods are now marked as `#[inline]` in order to allow rustc to choose to inline them if it deems it more optimal.
* Cleaned up any other clippy lints.


## Verification Evidence

Here are the changes required to upgrade the `surrealdb` repo to this new version of revisioned:
https://github.com/surrealdb/surrealdb/compare/main...ssttuu:surrealdb:dev/stu/check-revision-upgrade?expand=1