### PR TITLE
Add support for `bytes::Bytes`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "revision"
 publish = true
 edition = "2021"
-version = "0.14.0"
+version = "0.15.0"
 license = "Apache-2.0"
 readme = "README.md"
 authors = ["Tobie Morgan Hitchcock <tobie@surrealdb.com>"]
@@ -20,8 +20,9 @@ members = ["derive"]
 default = []
 
 [dependencies]
+bytes = { version = "1.11.0" }
 chrono = { version = "0.4.42", features = ["serde"], optional = true }
-derive = { version = "0.14.0", package = "revision-derive", path = "derive" }
+revision-derive = { version = "0.15.0", path = "derive" }
 geo = { version = "0.31.0", features = ["use-serde"], optional = true }
 ordered-float = { version = "5.1.0", optional = true }
 regex = { version = "1.12.2", optional = true }

--- a/benches/generic.rs
+++ b/benches/generic.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use revision::prelude::*;
 use std::borrow::Cow;
@@ -34,7 +35,8 @@ struct ComplexData {
 
 	// Strings and collections
 	text: String,
-	bytes: Vec<u8>,
+	bytes: Bytes,
+	bytes_vec: Vec<u8>,
 	numbers: Vec<i32>,
 
 	// Additional vector types for comprehensive testing
@@ -126,6 +128,7 @@ impl ComplexData {
 
 			text: "The quick brown fox jumps over the lazy dog".repeat(size_factor / 10 + 1),
 			bytes: (0..size_factor).map(|i| (i % 256) as u8).collect(),
+			bytes_vec: (0..size_factor).map(|i| (i % 256) as u8).collect(),
 			numbers: (0..size_factor).map(|i| i as i32).collect(),
 
 			// Initialize additional vector types with varying patterns

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -2,7 +2,7 @@
 name = "revision-derive"
 publish = true
 edition = "2021"
-version = "0.14.0"
+version = "0.15.0"
 license = "Apache-2.0"
 readme = "README.md"
 authors = ["Tobie Morgan Hitchcock <tobie@surrealdb.com>"]

--- a/src/implementations/bytes.rs
+++ b/src/implementations/bytes.rs
@@ -1,0 +1,91 @@
+use crate::implementations::vecs::serialize_bytes;
+use crate::Error;
+use crate::{DeserializeRevisioned, Revisioned, SerializeRevisioned};
+use ::bytes::Bytes;
+use std::io::ErrorKind::UnexpectedEof;
+use std::io::Read;
+
+impl SerializeRevisioned for Bytes {
+	#[inline]
+	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
+		serialize_bytes(self.as_ref(), writer)
+	}
+}
+
+impl DeserializeRevisioned for Bytes {
+	#[inline]
+	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
+		let len = usize::deserialize_revisioned(reader)?;
+		if len == 0 {
+			return Ok(Bytes::new());
+		}
+
+		let mut bytes = Vec::with_capacity(len);
+		let mut take = reader.take(len as u64);
+		if len != take.read_to_end(&mut bytes).map_err(Error::Io)? {
+			return Err(Error::Io(UnexpectedEof.into()));
+		}
+		Ok(Bytes::from(bytes))
+	}
+}
+
+impl Revisioned for Bytes {
+	#[inline]
+	fn revision() -> u16 {
+		1
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::{from_slice, to_vec};
+
+	#[test]
+	fn test_revision_specialised_vec_u8_serialization_single() {
+		let original = Bytes::from(vec![42]);
+		let serialized = to_vec(&original).unwrap();
+		let deserialized: Bytes = from_slice(&serialized).unwrap();
+		assert_eq!(original, deserialized);
+		assert_eq!(deserialized.len(), 1);
+		assert_eq!(deserialized[0], 42);
+	}
+
+	#[test]
+	fn test_revision_specialised_vec_u8_serialization_multiple() {
+		let data = vec![0, 1, 127, 128, 255];
+		let original = Bytes::from(data.clone());
+		let serialized = to_vec(&original).unwrap();
+		let deserialized: Bytes = from_slice(&serialized).unwrap();
+		assert_eq!(original, deserialized);
+		assert_eq!(deserialized.as_ref(), &data);
+	}
+
+	#[test]
+	fn test_revision_specialised_vec_u8_serialization_large() {
+		let data: Vec<u8> = (0..=255).collect();
+		let original = Bytes::from(data.clone());
+		let serialized = to_vec(&original).unwrap();
+		let deserialized: Bytes = from_slice(&serialized).unwrap();
+		assert_eq!(original, deserialized);
+		assert_eq!(deserialized.len(), 256);
+		assert_eq!(deserialized.as_ref(), &data);
+	}
+
+	#[test]
+	fn test_revision_specialised_vec_u8_conversion() {
+		let original_vec = vec![1, 2, 3, 4, 5];
+		let wrapper: Bytes = original_vec.clone().into();
+		assert_eq!(wrapper.as_ref(), &original_vec);
+
+		let extracted_vec: Vec<u8> = wrapper.into();
+		assert_eq!(extracted_vec, original_vec);
+	}
+
+	#[test]
+	fn test_revision_specialised_vec_u8_as_ref() {
+		let wrapper = Bytes::from(vec![1, 2, 3]);
+		let slice: &[u8] = wrapper.as_ref();
+		assert_eq!(slice, &[1, 2, 3]);
+	}
+}

--- a/src/implementations/mod.rs
+++ b/src/implementations/mod.rs
@@ -2,6 +2,7 @@ mod arc;
 pub mod arrays;
 pub mod bound;
 pub mod boxes;
+pub mod bytes;
 pub mod chrono;
 pub mod collections;
 pub mod cow;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ pub mod implementations;
 pub mod specialised;
 
 pub use crate::error::Error;
-pub use derive::revisioned;
+pub use revision_derive::revisioned;
 
 use std::any::TypeId;
 use std::io::{Read, Write};


### PR DESCRIPTION
This PR adds support for `bytes::Bytes`.