### PR TITLE
Add support for `Arc<str>` serialization and deserialization

### DIFF
--- a/src/implementations/arc.rs
+++ b/src/implementations/arc.rs
@@ -35,6 +35,28 @@ where
 	}
 }
 
+// Specialized implementations for Arc<str>
+impl SerializeRevisioned for Arc<str> {
+	#[inline]
+	fn serialize_revisioned<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
+		self.as_ref().serialize_revisioned(writer)
+	}
+}
+
+impl DeserializeRevisioned for Arc<str> {
+	#[inline]
+	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
+		String::deserialize_revisioned(reader).map(Arc::from)
+	}
+}
+
+impl Revisioned for Arc<str> {
+	#[inline]
+	fn revision() -> u16 {
+		1
+	}
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -47,6 +69,18 @@ mod tests {
 		val.serialize_revisioned(&mut mem).unwrap();
 		assert_eq!(mem.len(), 5);
 		let out = DeserializeRevisioned::deserialize_revisioned(&mut mem.as_slice()).unwrap();
+		assert_eq!(val, out);
+	}
+
+	#[test]
+	fn test_arc_str() {
+		let val: Arc<str> = Arc::from("hello world");
+		let mut mem: Vec<u8> = vec![];
+		val.serialize_revisioned(&mut mem).unwrap();
+		assert_eq!(mem.len(), 12); // 11 chars + 1 byte for length encoding
+		let out: Arc<str> =
+			<Arc<str> as DeserializeRevisioned>::deserialize_revisioned(&mut mem.as_slice())
+				.unwrap();
 		assert_eq!(val, out);
 	}
 }


### PR DESCRIPTION
This PR adds specialized trait implementations for `Arc<str>`, enabling direct serialization and deserialization of `Arc<str>` values.

### Background

The existing generic `Arc<T>` implementation requires `T: DeserializeRevisioned`, but `str` is unsized and cannot implement `DeserializeRevisioned` directly. This follows the same pattern established for `Cow<'_, str>` in `cow.rs`.

### Changes

- Added `SerializeRevisioned` impl for `Arc<str>` - delegates to `str::serialize_revisioned`
- Added `DeserializeRevisioned` impl for `Arc<str>` - deserializes a `String` and converts via `Arc::from`
- Added `Revisioned` impl for `Arc<str>` - returns revision 1
- Added unit test for round-trip serialization