### PR TITLE
feat: always enable skip revision APIs; bump to 0.19.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "revision-derive"]
 
 [workspace.package]
 edition = "2024"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Tobie Morgan Hitchcock <tobie@surrealdb.com>"]
 description = "A serialization and deserialization implementation which allows for schema-evolution."
 repository = "https://github.com/surrealdb/revision"
@@ -33,10 +33,9 @@ autobenches = false
 default = ["specialised-vectors"]
 specialised-vectors = []
 fixed-width-encoding = []
-skip = []
 
 [dependencies]
-revision-derive = { version = "0.18.0", path = "revision-derive" }
+revision-derive = { version = "0.19.0", path = "revision-derive" }
 bytes = { version = "1.11.0", optional = true }
 chrono = { version = "0.4.42", features = ["serde"], optional = true }
 geo = { version = "0.31.0", features = ["use-serde"], optional = true }
@@ -57,7 +56,6 @@ paste = "1.0"
 [[test]]
 name = "skip"
 path = "tests/skip.rs"
-required-features = ["skip"]
 
 [[bench]]
 name = "roaring"
@@ -136,27 +134,23 @@ harness = false
 [[bench]]
 name = "skip"
 harness = false
-required-features = ["skip"]
 
 [[bench]]
 name = "skip_nested_struct"
 harness = false
-required-features = ["skip"]
 
 [[bench]]
 name = "skip_nested_btreemap"
 harness = false
-required-features = ["skip"]
 
 [[bench]]
 name = "skip_surrealdb_doc"
 harness = false
-required-features = ["skip"]
 
 [[bench]]
 name = "skip_mixed_btreemap_nested"
 harness = false
-required-features = ["skip", "uuid"]
+required-features = ["uuid"]
 
 [[bench]]
 name = "vec_bool_comparison"

--- a/revision-derive/src/expand/mod.rs
+++ b/revision-derive/src/expand/mod.rs
@@ -132,7 +132,6 @@ pub fn revision(attr: TokenStream, input: TokenStream) -> syn::Result<TokenStrea
 
 	let skip_revisioned_impl = if skip_derive_enabled {
 		quote! {
-			#[cfg(feature = "skip")]
 			impl ::revision::SkipRevisioned for #name {
 				fn skip_revisioned<R: ::std::io::Read>(reader: &mut R)
 					-> ::std::result::Result<(), ::revision::Error> {
@@ -163,7 +162,6 @@ pub fn revision(attr: TokenStream, input: TokenStream) -> syn::Result<TokenStrea
 
 	let skip_check_impl = if skip_derive_enabled && attrs.0.deserialize {
 		quote! {
-			#[cfg(feature = "skip")]
 			impl ::revision::SkipCheckRevisioned for #name {
 				fn skip_check_revisioned<R: ::std::io::Read>(reader: &mut R)
 					-> ::std::result::Result<(), ::revision::Error> {

--- a/revision-derive/src/lib.rs
+++ b/revision-derive/src/lib.rs
@@ -69,12 +69,10 @@ mod expand;
 ///
 /// By default both serialization and deserialization are enabled.
 ///
-/// ## Skipping payloads (`revision` feature **`skip`**)
+/// ## Skipping payloads
 ///
-/// With `revision` built using `--features skip`, and your crate enabling a **`skip`** feature that
-/// activates `revision/skip`, the macro emits `SkipRevisioned` and (when deserialization is enabled)
-/// `SkipCheckRevisioned` implementations behind `#[cfg(feature = "skip")]`. Disable per type via
-/// `#[revisioned(revision = N, skip = false)]` (defaults to the same toggle as deserialization).
+/// By default, deserialization enabled types also get `SkipRevisioned` and `SkipCheckRevisioned`
+/// implementations. Opt out per type with `#[revisioned(revision = N, skip = false)]`.
 ///
 /// ## Example
 ///

--- a/src/implementations/mod.rs
+++ b/src/implementations/mod.rs
@@ -27,7 +27,6 @@ pub mod uuid;
 pub mod vecs;
 pub mod wrapping;
 
-#[cfg(feature = "skip")]
 mod skip;
 
 #[cfg(test)]

--- a/src/implementations/primitives.rs
+++ b/src/implementations/primitives.rs
@@ -904,7 +904,6 @@ mod tests {
 	test_integer_compat!(compat_i128, i128);
 	test_integer_compat!(compat_u128, u128);
 
-	#[cfg(feature = "skip")]
 	#[test]
 	fn skip_u32_consumes_serialised_length() {
 		use crate::{SerializeRevisioned, skip_slice};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@
 pub mod error;
 pub mod implementations;
 
-#[cfg(feature = "skip")]
 pub mod slice_reader;
 
 pub use crate::error::Error;
@@ -21,10 +20,8 @@ pub use revision_derive::revisioned;
 use std::any::TypeId;
 use std::io::{Read, Write};
 
-#[cfg(feature = "skip")]
 pub use slice_reader::{SliceReader, advance_read};
 
-#[cfg(feature = "skip")]
 pub trait SkipRevisioned: Revisioned {
 	fn skip_revisioned<R: Read>(r: &mut R) -> Result<(), Error>;
 
@@ -38,38 +35,32 @@ pub trait SkipRevisioned: Revisioned {
 	}
 }
 
-#[cfg(feature = "skip")]
 pub trait SkipCheckRevisioned: Revisioned {
 	fn skip_check_revisioned<R: Read>(r: &mut R) -> Result<(), Error>;
 }
 
-#[cfg(feature = "skip")]
 #[inline]
 pub fn skip_revisioned<T: SkipRevisioned, R: Read>(r: &mut R) -> Result<(), Error> {
 	T::skip_revisioned(r)
 }
 
 /// Alias for [`skip_revisioned`].
-#[cfg(feature = "skip")]
 #[inline]
 pub fn skip_reader<T: SkipRevisioned, R: Read>(r: &mut R) -> Result<(), Error> {
 	skip_revisioned::<T, R>(r)
 }
 
-#[cfg(feature = "skip")]
 #[inline]
 pub fn skip_check_revisioned<T: SkipCheckRevisioned, R: Read>(r: &mut R) -> Result<(), Error> {
 	T::skip_check_revisioned(r)
 }
 
 /// Alias for [`skip_check_revisioned`].
-#[cfg(feature = "skip")]
 #[inline]
 pub fn skip_check_reader<T: SkipCheckRevisioned, R: Read>(r: &mut R) -> Result<(), Error> {
 	skip_check_revisioned::<T, R>(r)
 }
 
-#[cfg(feature = "skip")]
 #[inline]
 pub fn skip_slice<T: SkipRevisioned>(bytes: &[u8]) -> Result<usize, Error> {
 	let mut sr = SliceReader::new(bytes);
@@ -77,7 +68,6 @@ pub fn skip_slice<T: SkipRevisioned>(bytes: &[u8]) -> Result<usize, Error> {
 	Ok(sr.consumed_len())
 }
 
-#[cfg(feature = "skip")]
 #[inline]
 pub fn skip_check_slice<T: SkipCheckRevisioned>(bytes: &[u8]) -> Result<usize, Error> {
 	let mut cursor = bytes;
@@ -88,7 +78,6 @@ pub fn skip_check_slice<T: SkipCheckRevisioned>(bytes: &[u8]) -> Result<usize, E
 
 pub mod prelude {
 	pub use crate::{DeserializeRevisioned, Revisioned, SerializeRevisioned, revisioned};
-	#[cfg(feature = "skip")]
 	pub use crate::{
 		SkipCheckRevisioned, SkipRevisioned, skip_check_reader, skip_check_revisioned,
 		skip_check_slice, skip_reader, skip_revisioned, skip_slice,

--- a/tests/skip.rs
+++ b/tests/skip.rs
@@ -1,4 +1,3 @@
-#![cfg(feature = "skip")]
 #![allow(dead_code)]
 
 use revision::{


### PR DESCRIPTION
### What is the motivation?

The `skip` Cargo feature added friction for dependents that need `SkipRevisioned` / `SkipCheckRevisioned` (extra feature wiring and conditional compilation). Making skip APIs always available matches typical usage and simplifies integration (for example SurrealDB and other crates no longer need to thread a `revision/skip` feature through their own feature flags).

### What does this change do?

- Removes the `skip` workspace feature from `revision` and always compiles skip-related APIs: `SkipRevisioned`, `SkipCheckRevisioned`, `SliceReader`, `skip_slice`, helpers in the prelude, and the `implementations::skip` module.
- Updates `revision-derive` so generated `SkipRevisioned` / `SkipCheckRevisioned` impls are no longer behind `#[cfg(feature = "skip")]`; per-type opt-out remains via `#[revisioned(..., skip = false)]`.
- Drops `required-features = ["skip"]` from the skip integration test and skip benchmarks (the mixed btreemap bench still requires `uuid` only).
- Bumps workspace / crate versions to **0.19.0**.

### What is your testing strategy?

GitHub Actions CI on this PR; local `cargo test` and benches as needed.

### Security considerations

None. This is a public API surface and build-layout change only; no new network or crypto surface.

### Is this related to any issues?

No related issues.

### Breaking change note

Dependents that enabled `revision`'s `skip` feature must drop that feature from their `Cargo.toml` (the feature no longer exists). Behaviour for code that already used skip APIs with the feature enabled should be unchanged.