### PR TITLE
chore: bump version to 0.20.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "revision-derive"]
 
 [workspace.package]
 edition = "2024"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Tobie Morgan Hitchcock <tobie@surrealdb.com>"]
 description = "A serialization and deserialization implementation which allows for schema-evolution."
 repository = "https://github.com/surrealdb/revision"
@@ -35,7 +35,7 @@ specialised-vectors = []
 fixed-width-encoding = []
 
 [dependencies]
-revision-derive = { version = "0.19.0", path = "revision-derive" }
+revision-derive = { version = "0.20.0", path = "revision-derive" }
 bytes = { version = "1.11.0", optional = true }
 chrono = { version = "0.4.42", features = ["serde"], optional = true }
 geo = { version = "0.31.0", features = ["use-serde"], optional = true }


### PR DESCRIPTION
## Motivation

Prepare a minor release after the WalkRevisioned and related API work merged on `main`.

## What does this change do?

Bumps workspace package version **0.19.0 → 0.20.0** and aligns the `revision-derive` path dependency version pin.

## Testing strategy

`cargo check -p revision -p revision-derive --all-features`

## Security considerations

None — metadata-only change.

## Related issues

None.

## Contributing

- [x] I have read the contributing guidelines for this repository.