### PR TITLE
feat: expose REVISION as inherent const on derived types

### DIFF
--- a/revision-derive/src/expand/mod.rs
+++ b/revision-derive/src/expand/mod.rs
@@ -252,6 +252,10 @@ pub fn revision(attr: TokenStream, input: TokenStream) -> syn::Result<TokenStrea
 		#skip_check_impl
 		#walk_impl
 
+		impl #name {
+			pub const REVISION: u16 = #revision_lit;
+		}
+
 		impl ::revision::Revisioned for #name {
 			#[inline]
 			fn revision() -> u16{

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -6,6 +6,9 @@ use revision::revisioned;
 use revision::{DeserializeRevisioned, SerializeRevisioned};
 use std::num::Wrapping;
 
+const _: () = assert!(TestEnum::REVISION == 3);
+const _: () = assert!(<TestEnum>::REVISION <= 3);
+
 #[revisioned(revision = 3)]
 #[derive(Debug, PartialEq)]
 pub enum TestEnum {


### PR DESCRIPTION
## Summary

- Derive macro now emits `impl T { pub const REVISION: u16 = N; }` alongside the existing `impl Revisioned for T` so the schema version is reachable in `const` contexts.
- Enables downstream compile-time guards like:
  ```rust
  const _: () = assert!(
      <Record>::REVISION <= 1,
      "Record::kv_decode_value_with_id only handles revisions 1..=1"
  );
  ```
  which previously weren't expressible, since `Revisioned::revision()` is a regular fn, not `const fn`.
- Purely additive: no change to the `Revisioned` trait, no breakage for external manual impls.

## Implementation notes

- Single edit in `revision-derive/src/expand/mod.rs` — appended an inherent impl block to the final `quote!` output. Reuses the existing `#name` and `#revision_lit` tokens.
- `pub` on an inherent const is capped by the type's own visibility, so a `pub(crate)` struct's const stays `pub(crate)` — no need to thread visibility through.

## Test plan

- [x] `cargo build` — clean.
- [x] `cargo test --test test` — existing tests still pass.
- [x] Added `const _: () = assert!(TestEnum::REVISION == 3);` and `const _: () = assert!(<TestEnum>::REVISION <= 3);` in `tests/test.rs` — the file failing to compile would prove either the derive or the assertion is wrong. Both forms compile.