### PR TITLE
fix: document macro-emitted REVISION const to satisfy missing_docs

### DIFF
--- a/revision-derive/src/expand/mod.rs
+++ b/revision-derive/src/expand/mod.rs
@@ -253,6 +253,7 @@ pub fn revision(attr: TokenStream, input: TokenStream) -> syn::Result<TokenStrea
 		#walk_impl
 
 		impl #name {
+			/// The revision number of this type, as declared via `#[revisioned(revision = N)]`.
 			pub const REVISION: u16 = #revision_lit;
 		}
 


### PR DESCRIPTION
## Summary

- The `#[revisioned(revision = N)]` attribute macro expands to an `impl` block exposing `pub const REVISION: u16` without a doc comment.
- In downstream crates that set `#![warn(missing_docs)]` on a module and then `pub use` a revisioned type from that module, the macro-emitted constant becomes publicly reachable from a `missing_docs`-enforced scope and trips the lint.
- This adds a brief doc comment to the emitted constant so it carries its own docs and no longer fails `missing_docs` downstream.

## Test plan

- [x] `cargo build` succeeds locally
- [ ] CI green