### PR TITLE
Optimise Cargo features to avoid pulling in unused features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ criterion = "0.7.0"
 bincode = "1.3.3"
 serde = "1.0.228"
 paste = "1.0"
+roaring = { version = "0.11.2", features = ["serde"] }
 
 [[test]]
 name = "skip"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,13 +37,13 @@ fixed-width-encoding = []
 [dependencies]
 revision-derive = { version = "0.22.0", path = "revision-derive" }
 bytes = { version = "1.11.0", optional = true }
-chrono = { version = "0.4.42", features = ["serde"], optional = true }
-geo = { version = "0.31.0", features = ["use-serde"], optional = true }
+chrono = { version = "0.4.42", default-features = false, features = ["std"], optional = true }
+geo = { version = "0.32.0", default-features = false, features = ["use-serde"], optional = true }
 imbl = { version = "6.1.0", optional = true }
 ordered-float = { version = "5.1.0", optional = true }
 regex = { version = "1.12.2", optional = true }
-roaring = { version = "0.11.2", features = ["serde"], optional = true }
-rust_decimal = { version = "1.39.0", optional = true }
+roaring = { version = "0.11.2", optional = true }
+rust_decimal = { version = "1.39.0", default-features = false, optional = true }
 uuid = { version = "1.19.0", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## What is the motivation?

Several optional dependencies in `revision` were requesting features they don't actually use, causing downstream crates to compile unnecessary code — most notably `chrono`'s clock stack (`iana-time-zone`, platform timezone bindings) and serde impls for types that revision serialises through its own binary protocol.

## What does this change do?

Trims four optional dependency feature sets to exactly what revision needs:

- **`geo`**: bumped to `0.32.0`, `default-features = false` — avoids pulling in `rstar`, spatial indexing crates and a second copy of `geo-types` with its defaults
- **`chrono`**: `default-features = false, features = ["std"]` — removes the `clock` feature and its transitive stack (`iana-time-zone`, `core-foundation-sys`, `wasm-bindgen` glue, Windows API bindings); revision only accesses datetime fields, never reads the system clock
- **`roaring`**: removes `features = ["serde"]` — revision calls `serialize_into`/`deserialize_from` (roaring's native I/O), not serde
- **`rust_decimal`**: `default-features = false` — revision calls `Decimal::serialize()`/`Decimal::deserialize()` (fixed 16-byte inherent methods), not serde

## What is your testing strategy?

`cargo check --all-features` and existing test suite.

## Security Considerations

No security implications — dependency-only change with no behavioural changes.

## Is this related to any issues?

No related issues.

## Have you read the Contributing Guidelines?

- [x] Yes