### PR TITLE
perf(walker): zero-copy walk_field for Wire-repr parents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,8 +53,20 @@ per-field encoding-override attributes.
   parent walker is `IndexedBorrowed`, `walk_<field>` for `indexed_map` /
   `indexed_seq` / `indexed_set` fields extracts the field's bytes
   directly from the parent's offset table (`Cow::Borrowed`), skipping
-  the decode + re-encode round-trip. Wire / ConvertedOwned parents
-  still take the slower path.
+  the decode + re-encode round-trip.
+- **Zero-copy `walk_<field>` for Wire-repr parents too.** When the
+  parent walker is `Wire` (sequential optimised or current-rev
+  legacy), the macro emits a `skip_indexed_*` call bracketed by
+  `BorrowedReader::remaining()` snapshots and borrows the field's
+  exact wire bytes from the difference. Same zero-allocation result
+  as the indexed-struct path, just derived by skip+slice instead of
+  offset-table lookup. Only the rare `ConvertedOwned` (cross-rev
+  `convert_fn` re-encode) path still allocates, because its bytes
+  are owned by the walker and don't outlive `self`.
+- **New trait method `BorrowedReader::remaining()`** returns the
+  unconsumed tail as a borrowed slice — enables the Wire-repr
+  fast path. Default impl returns `&[]`; `&[u8]` and `SliceReader<'a>`
+  override with the actual tail.
 
 ### Pin tests
 

--- a/revision-derive/src/expand/walk.rs
+++ b/revision-derive/src/expand/walk.rs
@@ -605,45 +605,89 @@ fn emit_struct_methods(
 		// For fields with `#[revision(indexed_map)]` / `#[revision(indexed_seq)]`,
 		// the inner walker is `IndexedMapWalker` / `IndexedSeqWalker` rather
 		// than the field type's own `WalkRevisioned::Walker`. These walkers
-		// borrow from a payload slice, so we return an owned-bytes wrapper
-		// (`IndexedMapView` / `IndexedSeqView`) that the caller
-		// keeps alive while borrowing the walker from it.
+		// borrow from a payload slice, so we return a wire-bytes wrapper
+		// (`IndexedMapView` / `IndexedSeqView`) holding `Cow<'r, [u8]>`.
 		//
-		// Fast path: when the parent walker is `IndexedBorrowed`
-		// (optimised + `struct = "indexed"`), the field's canonical bytes
-		// already live at `bytes[offsets[i]..offsets[i+1]]`. Extract
-		// directly and wrap in `Cow::Borrowed` — zero allocation, the view
-		// preserves the parent's `'r` lifetime.
+		// Three paths, in order of preference (most-borrowed → most-allocating):
 		//
-		// Fallback: Wire or ConvertedOwned reprs go through decode +
-		// re-encode (one alloc + one walk per field) since the field's
-		// canonical bytes aren't addressable via an offset table there.
-		let fast_path_extract = |view_ty: &TokenStream| -> TokenStream {
-			quote! {
-				if let #walker_repr_name::IndexedBorrowed { bytes, field_count, .. } = &self.repr {
-					let __bytes_borrow: &'r [u8] = *bytes;
-					let __fc = *field_count as usize;
-					let __off_base = (#pos_lit as usize) * 4;
-					let __start = u32::from_le_bytes(
-						__bytes_borrow[__off_base..__off_base + 4]
-							.try_into()
-							.expect("4-byte slice"),
-					) as usize;
-					let __end = if (#pos_lit as usize) + 1 < __fc {
-						u32::from_le_bytes(
-							__bytes_borrow[__off_base + 4..__off_base + 8]
+		// 1. `IndexedBorrowed` parent (optimised + `struct = "indexed"`): the
+		//    field's canonical bytes already live at `parent.bytes[offsets[i]
+		//    ..offsets[i+1]]`. Extract directly via `Cow::Borrowed` with the
+		//    parent's `'r` lifetime. Zero allocation, O(1) lookup.
+		// 2. `Wire` parent (sequential optimised or current-rev legacy): the
+		//    field's bytes are next in the reader, but their length isn't
+		//    known up front. Capture `reader.remaining()` before and after a
+		//    `skip_indexed_*` call to derive the field's exact slice, then
+		//    extend the borrow to `'r` via the same unsafe pattern used by
+		//    `read_borrowed_bytes`. Zero allocation, O(field bytes) skip.
+		// 3. `ConvertedOwned` parent (cross-rev `convert_fn` round-trip):
+		//    the parent's bytes are an owned `Vec<u8>` that dies with `self`
+		//    on a `&self`/`self` accessor, so we can't borrow from it. Decode
+		//    the field into the runtime type and re-encode into `Cow::Owned`.
+		//    One allocation per call; rare path.
+		// `self_expr` is the identifier used for the walker instance — `self`
+		// for `walk_<field>(&mut self)` and `__self` for
+		// `into_walk_<field>(self)` after the `let mut __self = self;` rebind.
+		let fast_path_indexed_borrowed =
+			|view_ty: &TokenStream, self_expr: &TokenStream| -> TokenStream {
+				quote! {
+					if let #walker_repr_name::IndexedBorrowed { bytes, field_count, .. } = &#self_expr.repr {
+						let __bytes_borrow: &'r [u8] = *bytes;
+						let __fc = *field_count as usize;
+						let __off_base = (#pos_lit as usize) * 4;
+						let __start = u32::from_le_bytes(
+							__bytes_borrow[__off_base..__off_base + 4]
 								.try_into()
 								.expect("4-byte slice"),
-						) as usize
-					} else {
-						__bytes_borrow.len()
+						) as usize;
+						let __end = if (#pos_lit as usize) + 1 < __fc {
+							u32::from_le_bytes(
+								__bytes_borrow[__off_base + 4..__off_base + 8]
+									.try_into()
+									.expect("4-byte slice"),
+							) as usize
+						} else {
+							__bytes_borrow.len()
+						};
+						return ::std::result::Result::Ok(
+							#view_ty::new(::std::borrow::Cow::Borrowed(&__bytes_borrow[__start..__end])),
+						);
+					}
+				}
+			};
+		// Wire-parent fast path: skip the field, derive its bytes from the
+		// before/after `remaining()` snapshots, lifetime-extend via the
+		// canonical unsafe pattern (peeked bytes stay valid for `'r` per the
+		// `BorrowedReader` contract).
+		let fast_path_wire = |view_ty: &TokenStream,
+		                      skip_call: &TokenStream,
+		                      self_expr: &TokenStream|
+		 -> TokenStream {
+			quote! {
+				if let #walker_repr_name::Wire { reader, .. } = &mut #self_expr.repr {
+					let __before = ::revision::BorrowedReader::remaining(*reader);
+					let __before_ptr = __before.as_ptr();
+					let __before_len = __before.len();
+					#skip_call
+					let __after_len = ::revision::BorrowedReader::remaining(*reader).len();
+					let __consumed_len = __before_len - __after_len;
+					// SAFETY: `BorrowedReader::remaining` returns a slice into
+					// the reader's stable buffer; the trait's safety contract
+					// guarantees `advance`/`skip` only moves the cursor, so
+					// the bytes captured by `__before_ptr` remain valid for
+					// the reader's lifetime `'r`. Same pattern as
+					// `read_borrowed_bytes` for `peek_bytes + advance`.
+					let __field_bytes: &'r [u8] = unsafe {
+						::std::slice::from_raw_parts(__before_ptr, __consumed_len)
 					};
 					return ::std::result::Result::Ok(
-						#view_ty::new(::std::borrow::Cow::Borrowed(&__bytes_borrow[__start..__end])),
+						#view_ty::new(::std::borrow::Cow::Borrowed(__field_bytes)),
 					);
 				}
 			}
 		};
+		let self_walk = quote! { self };
+		let self_into = quote! { __self };
 		let walk_return_ty;
 		let walk_body;
 		let into_walk_return_ty;
@@ -657,9 +701,16 @@ fn emit_struct_methods(
 				>
 			};
 			let view_ctor = quote! { ::revision::optimised::indexed::IndexedMapView };
-			let fast = fast_path_extract(&view_ctor);
+			let skip_call = quote! {
+				<#ty as ::revision::optimised::indexed::IndexedMapEncoded>::skip_indexed_map(*reader)?;
+			};
+			let fast_ib_w = fast_path_indexed_borrowed(&view_ctor, &self_walk);
+			let fast_w_w = fast_path_wire(&view_ctor, &skip_call, &self_walk);
+			let fast_ib_i = fast_path_indexed_borrowed(&view_ctor, &self_into);
+			let fast_w_i = fast_path_wire(&view_ctor, &skip_call, &self_into);
 			walk_body = quote! {
-				#fast
+				#fast_ib_w
+				#fast_w_w
 				let __v: #ty = self.#decode_name()?;
 				let mut __bytes = ::std::vec::Vec::new();
 				<#ty as ::revision::optimised::indexed::IndexedMapEncoded>::serialize_indexed_map(
@@ -673,8 +724,9 @@ fn emit_struct_methods(
 			};
 			into_walk_return_ty = walk_return_ty.clone();
 			into_walk_body = quote! {
-				#fast
 				let mut __self = self;
+				#fast_ib_i
+				#fast_w_i
 				let __v: #ty = __self.#decode_name()?;
 				let mut __bytes = ::std::vec::Vec::new();
 				<#ty as ::revision::optimised::indexed::IndexedMapEncoded>::serialize_indexed_map(
@@ -694,9 +746,16 @@ fn emit_struct_methods(
 				>
 			};
 			let view_ctor = quote! { ::revision::optimised::indexed::IndexedSeqView };
-			let fast = fast_path_extract(&view_ctor);
+			let skip_call = quote! {
+				<#ty as ::revision::optimised::indexed::IndexedSeqEncoded>::skip_indexed_seq(*reader)?;
+			};
+			let fast_ib_w = fast_path_indexed_borrowed(&view_ctor, &self_walk);
+			let fast_w_w = fast_path_wire(&view_ctor, &skip_call, &self_walk);
+			let fast_ib_i = fast_path_indexed_borrowed(&view_ctor, &self_into);
+			let fast_w_i = fast_path_wire(&view_ctor, &skip_call, &self_into);
 			walk_body = quote! {
-				#fast
+				#fast_ib_w
+				#fast_w_w
 				let __v: #ty = self.#decode_name()?;
 				let mut __bytes = ::std::vec::Vec::new();
 				<#ty as ::revision::optimised::indexed::IndexedSeqEncoded>::serialize_indexed_seq(
@@ -710,8 +769,9 @@ fn emit_struct_methods(
 			};
 			into_walk_return_ty = walk_return_ty.clone();
 			into_walk_body = quote! {
-				#fast
 				let mut __self = self;
+				#fast_ib_i
+				#fast_w_i
 				let __v: #ty = __self.#decode_name()?;
 				let mut __bytes = ::std::vec::Vec::new();
 				<#ty as ::revision::optimised::indexed::IndexedSeqEncoded>::serialize_indexed_seq(
@@ -731,9 +791,16 @@ fn emit_struct_methods(
 				>
 			};
 			let view_ctor = quote! { ::revision::optimised::indexed::IndexedSetView };
-			let fast = fast_path_extract(&view_ctor);
+			let skip_call = quote! {
+				<#ty as ::revision::optimised::indexed::IndexedSetEncoded>::skip_indexed_set(*reader)?;
+			};
+			let fast_ib_w = fast_path_indexed_borrowed(&view_ctor, &self_walk);
+			let fast_w_w = fast_path_wire(&view_ctor, &skip_call, &self_walk);
+			let fast_ib_i = fast_path_indexed_borrowed(&view_ctor, &self_into);
+			let fast_w_i = fast_path_wire(&view_ctor, &skip_call, &self_into);
 			walk_body = quote! {
-				#fast
+				#fast_ib_w
+				#fast_w_w
 				let __v: #ty = self.#decode_name()?;
 				let mut __bytes = ::std::vec::Vec::new();
 				<#ty as ::revision::optimised::indexed::IndexedSetEncoded>::serialize_indexed_set(
@@ -747,8 +814,9 @@ fn emit_struct_methods(
 			};
 			into_walk_return_ty = walk_return_ty.clone();
 			into_walk_body = quote! {
-				#fast
 				let mut __self = self;
+				#fast_ib_i
+				#fast_w_i
 				let __v: #ty = __self.#decode_name()?;
 				let mut __bytes = ::std::vec::Vec::new();
 				<#ty as ::revision::optimised::indexed::IndexedSetEncoded>::serialize_indexed_set(

--- a/src/slice_reader.rs
+++ b/src/slice_reader.rs
@@ -168,6 +168,34 @@ pub unsafe trait BorrowedReader: Read {
 	/// Used by optimised walkers and the encode side to compute offsets
 	/// relative to the start of an optimised compound's payload.
 	fn position(&self) -> usize;
+
+	/// The unconsumed tail as a borrowed slice.
+	///
+	/// Returns a view of the bytes the reader has yet to read, tied to the
+	/// reader's borrow. Unlike [`peek_bytes`](Self::peek_bytes), the caller
+	/// does not have to know the length in advance — and unlike `position`,
+	/// the returned slice is concrete bytes, not a count.
+	///
+	/// **Use case**: capture before/after slices around a `skip`-style call
+	/// to recover the field's exact wire bytes without decoding them:
+	///
+	/// ```ignore
+	/// let before = reader.remaining();        // &[u8] of all unread bytes
+	/// some_skip_routine(&mut reader)?;        // advances past one logical value
+	/// let after = reader.remaining();
+	/// let consumed_bytes = &before[..before.len() - after.len()];
+	/// // `consumed_bytes` is the just-skipped value's wire bytes, zero-copy.
+	/// ```
+	///
+	/// The default implementation returns `&[]`; readers that can provide
+	/// the unconsumed tail (i.e. all `BorrowedReader` impls in this crate)
+	/// override it. Callers reaching for the slice via the macro-emitted
+	/// `walk_<field>` accessor receive the override's result and so always
+	/// get a meaningful slice.
+	#[inline]
+	fn remaining(&self) -> &[u8] {
+		&[]
+	}
 }
 
 // SAFETY: `&[u8]::peek_bytes` returns a slice into the caller-owned buffer the
@@ -203,6 +231,13 @@ unsafe impl BorrowedReader for &[u8] {
 		// absolute position. Callers that need positions should use `SliceReader`.
 		0
 	}
+
+	#[inline]
+	fn remaining(&self) -> &[u8] {
+		// `*self` is `&[u8]` — the entire unread tail by definition (advancing
+		// replaces the slice with its suffix).
+		self
+	}
 }
 
 // SAFETY: `SliceReader<'a>` borrows an external `&'a [u8]` it never modifies.
@@ -227,6 +262,11 @@ unsafe impl<'a> BorrowedReader for SliceReader<'a> {
 	#[inline]
 	fn position(&self) -> usize {
 		self.consumed_len()
+	}
+
+	#[inline]
+	fn remaining(&self) -> &[u8] {
+		self.inner
 	}
 }
 

--- a/tests/walk_field_wire_zero_copy.rs
+++ b/tests/walk_field_wire_zero_copy.rs
@@ -1,0 +1,116 @@
+//! `walk_<field>` on `indexed_map` / `indexed_seq` / `indexed_set` fields takes
+//! a zero-copy path even when the parent walker is `Wire` repr (i.e. an
+//! optimised struct **without** `struct = "indexed"`).
+//!
+//! Mechanism: the macro emits a `skip_indexed_*` call bracketed by
+//! `BorrowedReader::remaining()` snapshots, then derives the field's exact
+//! wire bytes from the difference. The bytes are borrowed from the source
+//! buffer via the same unsafe lifetime-extension pattern used by
+//! `read_borrowed_bytes`.
+//!
+//! The pointer-aliasing assertion confirms the view's bytes lie inside the
+//! original source buffer — i.e. no copy happened.
+
+use std::collections::BTreeMap;
+
+use revision::prelude::*;
+
+#[revisioned(revision(1, encoding = "optimised"))]
+#[derive(Debug, Clone, PartialEq)]
+struct SequentialDoc {
+	id: u32,
+	#[revision(indexed_map)]
+	fields: BTreeMap<String, u32>,
+	#[revision(indexed_seq)]
+	tags: Vec<String>,
+}
+
+fn make_doc() -> SequentialDoc {
+	let mut fields = BTreeMap::new();
+	for s in ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel"] {
+		fields.insert(s.to_string(), s.len() as u32);
+	}
+	SequentialDoc {
+		id: 42,
+		fields,
+		tags: (0..10).map(|i| format!("tag-{i}")).collect(),
+	}
+}
+
+fn ptr_inside(haystack: &[u8], needle: &[u8]) -> bool {
+	let start = haystack.as_ptr() as usize;
+	let end = start + haystack.len();
+	let p = needle.as_ptr() as usize;
+	p >= start && p <= end
+}
+
+#[test]
+fn walk_indexed_map_field_borrows_from_wire_parent() {
+	let doc = make_doc();
+	let bytes = revision::to_vec(&doc).unwrap();
+
+	// Parent is `Wire` repr (sequential optimised struct, no `struct =
+	// "indexed"`). Per commit 13 of the design refactor, walk_<field> should
+	// still borrow the field's bytes directly from `bytes` — no allocation.
+	let mut r: &[u8] = &bytes;
+	let mut w = SequentialDoc::walk_revisioned(&mut r).unwrap();
+	w.skip_id().unwrap();
+	let view = w.walk_fields().unwrap();
+	let body = view.as_bytes();
+
+	assert!(
+		ptr_inside(&bytes, body),
+		"view bytes must lie inside source buffer (no copy); body ptr=0x{:x} range=0x{:x}..0x{:x}",
+		body.as_ptr() as usize,
+		bytes.as_ptr() as usize,
+		bytes.as_ptr() as usize + bytes.len(),
+	);
+
+	// And the view's walker still finds keys by binary search.
+	let map_walker = view.walker().unwrap();
+	let mut key_buf = Vec::new();
+	<String as SerializeRevisioned>::serialize_revisioned(&"delta".to_string(), &mut key_buf)
+		.unwrap();
+	let value_bytes = map_walker.find_value_bytes(|k| k.cmp(key_buf.as_slice())).unwrap();
+	let mut vr: &[u8] = value_bytes.unwrap();
+	let v: u32 = <u32 as DeserializeRevisioned>::deserialize_revisioned(&mut vr).unwrap();
+	assert_eq!(v, "delta".len() as u32);
+}
+
+#[test]
+fn walk_indexed_seq_field_borrows_from_wire_parent() {
+	let doc = make_doc();
+	let bytes = revision::to_vec(&doc).unwrap();
+
+	let mut r: &[u8] = &bytes;
+	let mut w = SequentialDoc::walk_revisioned(&mut r).unwrap();
+	w.skip_id().unwrap();
+	w.skip_fields().unwrap();
+	let view = w.walk_tags().unwrap();
+	let body = view.as_bytes();
+
+	assert!(ptr_inside(&bytes, body), "tags view must borrow from source buffer");
+
+	let seq = view.walker().unwrap();
+	assert_eq!(seq.len(), 10);
+	assert!(seq.is_indexed());
+	let mut elt: &[u8] = seq.element_bytes(5).unwrap();
+	let s: String = <String as DeserializeRevisioned>::deserialize_revisioned(&mut elt).unwrap();
+	assert_eq!(s, "tag-5");
+}
+
+#[test]
+fn walk_field_advances_parent_cursor_correctly() {
+	// After walk_<field>(), the parent walker's cursor must be past the
+	// field's bytes — same invariant as the slower decode+re-encode path.
+	// We verify by reading the NEXT field successfully.
+	let doc = make_doc();
+	let bytes = revision::to_vec(&doc).unwrap();
+
+	let mut r: &[u8] = &bytes;
+	let mut w = SequentialDoc::walk_revisioned(&mut r).unwrap();
+	w.skip_id().unwrap();
+	let _view = w.walk_fields().unwrap();
+	// Should now cleanly walk `tags`.
+	let _view2 = w.walk_tags().unwrap();
+}


### PR DESCRIPTION
## Summary

Stacks on PR #63. Closes the last walker allocation: `walk_<field>` for `indexed_map` / `indexed_seq` / `indexed_set` fields on a **Wire-repr** parent now borrows the field's wire bytes directly instead of decoding + re-encoding.

### Background

PR #63 (commit 6 of the design refactor) gave us a zero-copy fast path for `walk_<field>` when the parent walker is `IndexedBorrowed` — the field's canonical bytes already live at `parent.bytes[offsets[i]..offsets[i+1]]`, so we just slice them.

For `Wire` repr parents (sequential optimised struct, or current-rev legacy), the field's bytes are *also* in the right format on the wire — but their length isn't known up front, so the macro fell back to:

```rust
let v: VecMap<...> = self.decode_field_0()?;       // materialise
let mut bytes = Vec::new();
serialize_indexed_map(&v, &mut bytes)?;            // re-encode
Ok(IndexedMapView::new(Cow::Owned(bytes)))
```

That's a per-call allocation for bytes the wire already had. The honest fix is the option-B path from the recent code review: `skip_indexed_*` walks the bytes once (it already exists in the crate), so bracketing the skip with `BorrowedReader::remaining()` snapshots gives us start and end pointers without decoding anything.

### What changed

- **New trait method `BorrowedReader::remaining(&self) -> &[u8]`** returning the unconsumed tail. Default impl returns `&[]`; `&[u8]` and `SliceReader<'a>` override with the actual tail.
- **Macro emits the Wire-repr fast path** before the slow decode+re-encode fallback. Path order is now: `IndexedBorrowed` (slice from offset table) → `Wire` (skip + slice) → `ConvertedOwned` (decode + re-encode). The slow path only runs for cross-rev `convert_fn` parents, which can't expose 'r-lifetime borrows anyway.
- **Lifetime extension** uses the same `from_raw_parts` pattern as `read_borrowed_bytes` (the existing wrapper for `peek_bytes + advance`), justified by the `BorrowedReader` safety contract added in PR #61.

### Practical impact for surrealdb

The `struct = "indexed"` wrapping that surrealdb added on single-field wrappers (`Object`, `Array`, `Set`) was a workaround to dodge this slow path — it forced the parent into `IndexedBorrowed` repr unconditionally, at the cost of 4 bytes per record on the wire (the u32_le payload length). With this PR they can drop that wrapping and reclaim the 4 bytes while keeping the zero-alloc descent.

### Tests

`tests/walk_field_wire_zero_copy.rs` defines an optimised struct **without** `struct = "indexed"` containing `indexed_map` and `indexed_seq` fields, then asserts the view's bytes pointer lies inside the original source buffer — proving no copy happened. Also verifies that after `walk_<field>` the parent walker's cursor is past the field's bytes (the next field walks cleanly).

## Test plan

- [x] `cargo test`
- [x] `cargo test --all-features`
- [x] `cargo test --features fixed-width-encoding`
- [x] `cargo clippy --all-targets --all-features`
- [x] `cargo fmt --check`
- [x] `cargo doc --no-deps --all-features` (warning-free)
- [x] New regression test asserts pointer lies inside source buffer