### PR TITLE
perf(indexed): borrow offset tables instead of materialising Vec<u32>

### DIFF
--- a/src/optimised/indexed/map_walk.rs
+++ b/src/optimised/indexed/map_walk.rs
@@ -206,25 +206,33 @@ impl<'p, K, V> IndexedMapWalker<'p, K, V> {
 	}
 
 	/// Iterate key/value byte ranges in original insertion order. Indexed path only.
+	///
+	/// Forward-only by design: we carry `(k_start, v_start)` across iterations
+	/// and decode only the *next* entry's offsets each step, reusing them as
+	/// the current entry's end. This halves the per-entry decode count
+	/// relative to the naive `decode(i), decode(i+1)` pattern. The returned
+	/// iterator is `impl Iterator` (no `DoubleEndedIterator`), so callers
+	/// can't step backwards and observe stale state.
 	pub fn entries(&self) -> Option<impl Iterator<Item = (&'p [u8], &'p [u8])> + '_> {
 		let p = self.prologue.as_ref()?;
 		let keys = p.keys_region;
 		let vals = p.vals_region;
 		let n = self.len;
+		let (mut k_start, mut v_start) = if n > 0 {
+			(p.key_off(0) as usize, p.val_off(0) as usize)
+		} else {
+			(0, 0)
+		};
 		Some((0..n).map(move |i| {
-			let k_start = p.key_off(i) as usize;
-			let k_end = if i + 1 < n {
-				p.key_off(i + 1) as usize
+			let (k_end, v_end) = if i + 1 < n {
+				(p.key_off(i + 1) as usize, p.val_off(i + 1) as usize)
 			} else {
-				keys.len()
+				(keys.len(), vals.len())
 			};
-			let v_start = p.val_off(i) as usize;
-			let v_end = if i + 1 < n {
-				p.val_off(i + 1) as usize
-			} else {
-				vals.len()
-			};
-			(&keys[k_start..k_end], &vals[v_start..v_end])
+			let entry = (&keys[k_start..k_end], &vals[v_start..v_end]);
+			k_start = k_end;
+			v_start = v_end;
+			entry
 		}))
 	}
 

--- a/src/optimised/indexed/map_walk.rs
+++ b/src/optimised/indexed/map_walk.rs
@@ -25,6 +25,20 @@ use crate::optimised::indexed::seq_walk::FLAG_INDEXED;
 use crate::optimised::validation::{validate_key_region_ascending, validate_map_prologue};
 
 /// Walker over an indexed-map body.
+///
+/// Like [`IndexedSeqWalker`](super::IndexedSeqWalker), the offset table is
+/// borrowed directly from the payload. The wire format stores key and value
+/// offsets interleaved (`(u32_le key_off, u32_le val_off); count`), so we
+/// keep them as a single `&'p [u8]` of `count * 8` bytes; the key column
+/// lives at stride-8 offsets `0, 8, 16, …` and the value column at
+/// `4, 12, 20, …`. Decoding entries on demand via [`key_off`] / [`val_off`]
+/// trades one `u32::from_le_bytes` per access (essentially free) for
+/// eliminating the two `Vec<u32>` allocations that the previous shape paid
+/// on every walker construction — a measurable per-row cost on scan
+/// workloads.
+///
+/// [`key_off`]: MapPrologue::key_off
+/// [`val_off`]: MapPrologue::val_off
 #[derive(Debug)]
 pub struct IndexedMapWalker<'p, K, V> {
 	/// Bytes past the flags+len header. Either the (offsets + keys + values) layout
@@ -38,10 +52,37 @@ pub struct IndexedMapWalker<'p, K, V> {
 
 #[derive(Debug)]
 struct MapPrologue<'p> {
-	key_offsets: Vec<u32>,
-	val_offsets: Vec<u32>,
+	/// `count * 8` bytes of interleaved `(u32_le key_off, u32_le val_off)`
+	/// pairs, borrowed from the payload.
+	offset_table: &'p [u8],
 	keys_region: &'p [u8],
 	vals_region: &'p [u8],
+}
+
+impl<'p> MapPrologue<'p> {
+	/// Decode the `index`-th key offset (stride 8, column 0).
+	#[inline]
+	fn key_off(&self, index: usize) -> u32 {
+		let base = index * 8;
+		u32::from_le_bytes([
+			self.offset_table[base],
+			self.offset_table[base + 1],
+			self.offset_table[base + 2],
+			self.offset_table[base + 3],
+		])
+	}
+
+	/// Decode the `index`-th value offset (stride 8, column 1).
+	#[inline]
+	fn val_off(&self, index: usize) -> u32 {
+		let base = index * 8 + 4;
+		u32::from_le_bytes([
+			self.offset_table[base],
+			self.offset_table[base + 1],
+			self.offset_table[base + 2],
+			self.offset_table[base + 3],
+		])
+	}
 }
 
 impl<'p, K, V> IndexedMapWalker<'p, K, V> {
@@ -113,24 +154,15 @@ impl<'p, K, V> IndexedMapWalker<'p, K, V> {
 		if payload.len() < cursor + table_bytes {
 			return Err(Error::OptimisedSubReaderOverrun);
 		}
-
-		let mut key_offsets = Vec::with_capacity(len);
-		let mut val_offsets = Vec::with_capacity(len);
-		for i in 0..len {
-			let base = cursor + i * 8;
-			let ko = u32::from_le_bytes(payload[base..base + 4].try_into().unwrap());
-			let vo = u32::from_le_bytes(payload[base + 4..base + 8].try_into().unwrap());
-			key_offsets.push(ko);
-			val_offsets.push(vo);
-		}
+		// Borrow the interleaved `(key_off, val_off)` table directly from the
+		// payload; per-entry decode happens on access via `MapPrologue::key_off`
+		// / `val_off`. No `Vec<u32>` allocation per walker construction.
+		let offset_table = &payload[cursor..cursor + table_bytes];
 		cursor += table_bytes;
 
-		// Compute the keys region length from the last offset to the next entry.
-		// Encoded shape places the keys region immediately after the offset table.
-		// We learn the keys-region end by reading the last key_offset + the keys-region
-		// size, but the encoder didn't include a separate size — it's derivable as
-		// the next-region start. We expect the encoder to emit a u32_le keys_region_len
-		// header here to disambiguate. Add that now.
+		// `u32_le keys_region_len` and `u32_le vals_region_len` follow the
+		// interleaved offset table; together they tell us where the keys
+		// region ends and the vals region begins.
 		if payload.len() < cursor + 8 {
 			return Err(Error::OptimisedSubReaderOverrun);
 		}
@@ -150,19 +182,18 @@ impl<'p, K, V> IndexedMapWalker<'p, K, V> {
 
 		if validate {
 			validate_map_prologue(
-				&key_offsets,
-				&val_offsets,
+				offset_table,
+				len,
 				keys_region_len as u32,
 				vals_region_len as u32,
 			)?;
-			validate_key_region_ascending(keys_region, &key_offsets)?;
+			validate_key_region_ascending(keys_region, offset_table, len)?;
 		}
 
 		Ok(Self {
 			body: &payload[1 + varint_bytes..],
 			prologue: Some(MapPrologue {
-				key_offsets,
-				val_offsets,
+				offset_table,
 				keys_region,
 				vals_region,
 			}),
@@ -191,19 +222,17 @@ impl<'p, K, V> IndexedMapWalker<'p, K, V> {
 		let p = self.prologue.as_ref()?;
 		let keys = p.keys_region;
 		let vals = p.vals_region;
-		let kos = &p.key_offsets;
-		let vos = &p.val_offsets;
 		let n = self.len;
 		Some((0..n).map(move |i| {
-			let k_start = kos[i] as usize;
+			let k_start = p.key_off(i) as usize;
 			let k_end = if i + 1 < n {
-				kos[i + 1] as usize
+				p.key_off(i + 1) as usize
 			} else {
 				keys.len()
 			};
-			let v_start = vos[i] as usize;
+			let v_start = p.val_off(i) as usize;
 			let v_end = if i + 1 < n {
-				vos[i + 1] as usize
+				p.val_off(i + 1) as usize
 			} else {
 				vals.len()
 			};
@@ -225,18 +254,18 @@ impl<'p, K, V> IndexedMapWalker<'p, K, V> {
 		let mut hi = n;
 		while lo < hi {
 			let mid = lo + (hi - lo) / 2;
-			let k_start = p.key_offsets[mid] as usize;
+			let k_start = p.key_off(mid) as usize;
 			let k_end = if mid + 1 < n {
-				p.key_offsets[mid + 1] as usize
+				p.key_off(mid + 1) as usize
 			} else {
 				p.keys_region.len()
 			};
 			let key_bytes = &p.keys_region[k_start..k_end];
 			match predicate(key_bytes) {
 				Ordering::Equal => {
-					let v_start = p.val_offsets[mid] as usize;
+					let v_start = p.val_off(mid) as usize;
 					let v_end = if mid + 1 < n {
-						p.val_offsets[mid + 1] as usize
+						p.val_off(mid + 1) as usize
 					} else {
 						p.vals_region.len()
 					};

--- a/src/optimised/indexed/map_walk.rs
+++ b/src/optimised/indexed/map_walk.rs
@@ -63,25 +63,13 @@ impl<'p> MapPrologue<'p> {
 	/// Decode the `index`-th key offset (stride 8, column 0).
 	#[inline]
 	fn key_off(&self, index: usize) -> u32 {
-		let base = index * 8;
-		u32::from_le_bytes([
-			self.offset_table[base],
-			self.offset_table[base + 1],
-			self.offset_table[base + 2],
-			self.offset_table[base + 3],
-		])
+		crate::optimised::validation::decode_u32_le_at(self.offset_table, index * 8)
 	}
 
 	/// Decode the `index`-th value offset (stride 8, column 1).
 	#[inline]
 	fn val_off(&self, index: usize) -> u32 {
-		let base = index * 8 + 4;
-		u32::from_le_bytes([
-			self.offset_table[base],
-			self.offset_table[base + 1],
-			self.offset_table[base + 2],
-			self.offset_table[base + 3],
-		])
+		crate::optimised::validation::decode_u32_le_at(self.offset_table, index * 8 + 4)
 	}
 }
 

--- a/src/optimised/indexed/seq_walk.rs
+++ b/src/optimised/indexed/seq_walk.rs
@@ -26,10 +26,22 @@ pub const FLAG_INDEXED: u8 = 0b0000_0001;
 /// Walker over an indexed-seq body.
 ///
 /// `T` is recorded only for type-driven decode helpers; the walker itself stores raw bytes.
+///
+/// The offset table is borrowed directly from the payload as `&'p [u8]` (a
+/// contiguous `len * 4` slice of `u32_le` entries). Individual offsets are
+/// decoded on demand via [`offset_at`] — a single `u32::from_le_bytes` on a
+/// 4-byte window, essentially one aligned `mov` on common targets. Borrowing
+/// the table instead of materialising it into a `Vec<u32>` removes one
+/// allocation + `O(len)` copy loop from every walker construction; on
+/// scan-heavy workloads that fires per row per descent level.
+///
+/// [`offset_at`]: Self::offset_at
 #[derive(Debug)]
 pub struct IndexedSeqWalker<'p, T> {
 	body: &'p [u8],
-	offsets: Option<Vec<u32>>,
+	/// `None` on the legacy path; otherwise a `len * 4` byte slice of
+	/// `u32_le` element offsets borrowed from the payload.
+	offsets: Option<&'p [u8]>,
 	len: usize,
 	_marker: PhantomData<fn() -> T>,
 }
@@ -99,11 +111,11 @@ impl<'p, T> IndexedSeqWalker<'p, T> {
 		if payload.len() < cursor + table_bytes {
 			return Err(Error::OptimisedSubReaderOverrun);
 		}
-		let offsets = parse_offsets(&payload[cursor..cursor + table_bytes]);
+		let offsets = &payload[cursor..cursor + table_bytes];
 		cursor += table_bytes;
 		let body = &payload[cursor..];
 		if validate {
-			validate_seq_prologue(&offsets, body.len() as u32)?;
+			validate_seq_prologue(offsets, len, body.len() as u32)?;
 		}
 		Ok(Self {
 			body,
@@ -111,6 +123,16 @@ impl<'p, T> IndexedSeqWalker<'p, T> {
 			len,
 			_marker: PhantomData,
 		})
+	}
+
+	/// Decode the `index`-th offset from the borrowed table.
+	///
+	/// `offsets` is the table-bytes slice produced at construction
+	/// (`len * 4` bytes); the caller must have already validated `index < len`.
+	#[inline]
+	fn offset_at(offsets: &[u8], index: usize) -> u32 {
+		let base = index * 4;
+		u32::from_le_bytes([offsets[base], offsets[base + 1], offsets[base + 2], offsets[base + 3]])
 	}
 
 	#[inline]
@@ -133,14 +155,13 @@ impl<'p, T> IndexedSeqWalker<'p, T> {
 	pub fn element_bytes(&self, index: usize) -> Result<&'p [u8], Error> {
 		let offsets = self
 			.offsets
-			.as_ref()
 			.ok_or_else(|| Error::Deserialize("element_bytes called on non-indexed seq".into()))?;
 		if index >= self.len {
 			return Err(Error::Deserialize(format!("index {index} out of range ({})", self.len)));
 		}
-		let start = offsets[index] as usize;
+		let start = Self::offset_at(offsets, index) as usize;
 		let end = if index + 1 < self.len {
-			offsets[index + 1] as usize
+			Self::offset_at(offsets, index + 1) as usize
 		} else {
 			self.body.len()
 		};
@@ -152,11 +173,6 @@ impl<'p, T> IndexedSeqWalker<'p, T> {
 	pub fn body(&self) -> &'p [u8] {
 		self.body
 	}
-}
-
-#[inline]
-fn parse_offsets(bytes: &[u8]) -> Vec<u32> {
-	bytes.chunks_exact(4).map(|c| u32::from_le_bytes(c.try_into().unwrap())).collect()
 }
 
 /// Parse a `usize` varint matching the on-wire shape used by `Vec`/map lengths.

--- a/src/optimised/indexed/seq_walk.rs
+++ b/src/optimised/indexed/seq_walk.rs
@@ -131,8 +131,7 @@ impl<'p, T> IndexedSeqWalker<'p, T> {
 	/// (`len * 4` bytes); the caller must have already validated `index < len`.
 	#[inline]
 	fn offset_at(offsets: &[u8], index: usize) -> u32 {
-		let base = index * 4;
-		u32::from_le_bytes([offsets[base], offsets[base + 1], offsets[base + 2], offsets[base + 3]])
+		crate::optimised::validation::decode_u32_le_at(offsets, index * 4)
 	}
 
 	#[inline]

--- a/src/optimised/indexed/struct_walk.rs
+++ b/src/optimised/indexed/struct_walk.rs
@@ -77,7 +77,7 @@ impl<'p> IndexedStructWalker<'p> {
 		validate_struct_prologue(&payload[..prologue_bytes], count, 4, payload.len() as u32)?;
 		// First offset must point at start of body (`prologue_bytes`).
 		if count > 0 {
-			let first = u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]);
+			let first = crate::optimised::validation::decode_u32_le_at(payload, 0);
 			if (first as usize) < prologue_bytes {
 				return Err(Error::OptimisedOffsetOutOfRange {
 					offset: first,

--- a/src/optimised/indexed/struct_walk.rs
+++ b/src/optimised/indexed/struct_walk.rs
@@ -73,16 +73,17 @@ impl<'p> IndexedStructWalker<'p> {
 		if payload.len() < prologue_bytes {
 			return Err(Error::OptimisedSubReaderOverrun);
 		}
-		let offsets = parse_offsets(&payload[..prologue_bytes]);
-		validate_struct_prologue(&offsets, payload.len() as u32)?;
+		let count = field_count as usize;
+		validate_struct_prologue(&payload[..prologue_bytes], count, 4, payload.len() as u32)?;
 		// First offset must point at start of body (`prologue_bytes`).
-		if let Some(&first) = offsets.first()
-			&& (first as usize) < prologue_bytes
-		{
-			return Err(Error::OptimisedOffsetOutOfRange {
-				offset: first,
-				payload_len: prologue_bytes as u32,
-			});
+		if count > 0 {
+			let first = u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]);
+			if (first as usize) < prologue_bytes {
+				return Err(Error::OptimisedOffsetOutOfRange {
+					offset: first,
+					payload_len: prologue_bytes as u32,
+				});
+			}
 		}
 		Ok(Self {
 			payload,
@@ -212,11 +213,6 @@ impl<'p> IndexedStructWalker<'p> {
 // ```
 //
 // The macro emits this pattern directly per field.
-
-#[inline]
-fn parse_offsets(bytes: &[u8]) -> Vec<u32> {
-	bytes.chunks_exact(4).map(|c| u32::from_le_bytes(c.try_into().unwrap())).collect()
-}
 
 #[cfg(test)]
 mod tests {

--- a/src/optimised/validation.rs
+++ b/src/optimised/validation.rs
@@ -7,17 +7,21 @@
 
 use crate::Error;
 
-/// Decode the `index`-th `u32_le` offset from an interleaved offset-table byte
-/// slice with the given `stride`. The caller is responsible for ensuring
-/// `index * stride + 4 <= offset_bytes.len()`.
+/// Decode a `u32_le` from `bytes` at `byte_offset`. The single primitive shared
+/// by every indexed-walker / validator site that reads borrowed offset tables.
+///
+/// Caller is responsible for ensuring `byte_offset + 4 <= bytes.len()`; an
+/// out-of-range index panics via standard slice bounds checking. All current
+/// call sites either bounds-check the parent slice at construction
+/// (`payload.len() < cursor + table_bytes`) or run after `validate_*_prologue`
+/// has confirmed the table length, so the read is always in range.
 #[inline]
-fn decode_offset(offset_bytes: &[u8], index: usize, stride: usize) -> u32 {
-	let base = index * stride;
+pub(crate) fn decode_u32_le_at(bytes: &[u8], byte_offset: usize) -> u32 {
 	u32::from_le_bytes([
-		offset_bytes[base],
-		offset_bytes[base + 1],
-		offset_bytes[base + 2],
-		offset_bytes[base + 3],
+		bytes[byte_offset],
+		bytes[byte_offset + 1],
+		bytes[byte_offset + 2],
+		bytes[byte_offset + 3],
 	])
 }
 
@@ -38,7 +42,7 @@ pub fn validate_struct_prologue(
 ) -> Result<(), Error> {
 	let mut last: Option<u32> = None;
 	for i in 0..count {
-		let o = decode_offset(offset_bytes, i, stride);
+		let o = decode_u32_le_at(offset_bytes, i * stride);
 		if o > payload_len {
 			return Err(Error::OptimisedOffsetOutOfRange {
 				offset: o,
@@ -88,13 +92,13 @@ pub fn validate_key_region_ascending(
 	count: usize,
 ) -> Result<(), Error> {
 	for i in 1..count {
-		let prev_start = decode_offset(offset_table, i - 1, 8) as usize;
-		let curr_start = decode_offset(offset_table, i, 8) as usize;
+		let prev_start = decode_u32_le_at(offset_table, (i - 1) * 8) as usize;
+		let curr_start = decode_u32_le_at(offset_table, i * 8) as usize;
 		// `validate_map_prologue` already enforced monotonicity, so curr_start > prev_start.
 		// Last entry runs to keys_region.len(); intermediate to next offset.
 		let prev_end = curr_start;
 		let curr_end = if i + 1 < count {
-			decode_offset(offset_table, i + 1, 8) as usize
+			decode_u32_le_at(offset_table, (i + 1) * 8) as usize
 		} else {
 			keys_region.len()
 		};

--- a/src/optimised/validation.rs
+++ b/src/optimised/validation.rs
@@ -91,22 +91,29 @@ pub fn validate_key_region_ascending(
 	offset_table: &[u8],
 	count: usize,
 ) -> Result<(), Error> {
+	if count < 2 {
+		return Ok(());
+	}
+	// Carry `(prev_start, curr_start)` across iterations so each key offset is
+	// decoded exactly once instead of three times. `validate_map_prologue`
+	// already enforced monotonicity, so `curr_start > prev_start`. The last
+	// entry runs to `keys_region.len()`; intermediate entries to the next
+	// offset.
+	let mut prev_start = decode_u32_le_at(offset_table, 0) as usize;
+	let mut curr_start = decode_u32_le_at(offset_table, 8) as usize;
 	for i in 1..count {
-		let prev_start = decode_u32_le_at(offset_table, (i - 1) * 8) as usize;
-		let curr_start = decode_u32_le_at(offset_table, i * 8) as usize;
-		// `validate_map_prologue` already enforced monotonicity, so curr_start > prev_start.
-		// Last entry runs to keys_region.len(); intermediate to next offset.
-		let prev_end = curr_start;
 		let curr_end = if i + 1 < count {
 			decode_u32_le_at(offset_table, (i + 1) * 8) as usize
 		} else {
 			keys_region.len()
 		};
-		let prev = &keys_region[prev_start..prev_end];
+		let prev = &keys_region[prev_start..curr_start];
 		let curr = &keys_region[curr_start..curr_end];
 		if curr <= prev {
 			return Err(Error::OptimisedKeyRegionNotAscending);
 		}
+		prev_start = curr_start;
+		curr_start = curr_end;
 	}
 	Ok(())
 }

--- a/src/optimised/validation.rs
+++ b/src/optimised/validation.rs
@@ -71,6 +71,11 @@ pub fn validate_map_prologue(
 	keys_region_len: u32,
 	vals_region_len: u32,
 ) -> Result<(), Error> {
+	// Defensive smoke-test, not a wire-format guard: the only caller derives
+	// both `offset_table` (sliced as `len * 8` bytes) and `count` from the same
+	// payload length, so a real mismatch is unreachable. Kept so that any
+	// future caller passing inconsistent arguments fails loudly here instead
+	// of producing a slice-OOB panic deeper in the validator.
 	if offset_table.len() != count.saturating_mul(8) {
 		return Err(Error::OptimisedOffsetsNonMonotonic);
 	}
@@ -193,7 +198,10 @@ mod tests {
 
 	#[test]
 	fn map_prologue_rejects_mismatched_lengths() {
-		// Caller passes a `count` that doesn't match the slice — must reject.
+		// Defensive smoke-test for the `offset_table.len() != count * 8` guard.
+		// Unreachable from real callers (both arguments come from the same
+		// payload length) but kept so a future caller passing inconsistent
+		// arguments fails with a typed error instead of a slice-OOB panic.
 		// Simulated by packing 2 pairs (16 bytes) but claiming count=3.
 		let bytes = pack_interleaved(&[0, 4], &[0, 4]);
 		assert!(matches!(

--- a/src/optimised/validation.rs
+++ b/src/optimised/validation.rs
@@ -7,12 +7,38 @@
 
 use crate::Error;
 
+/// Decode the `index`-th `u32_le` offset from an interleaved offset-table byte
+/// slice with the given `stride`. The caller is responsible for ensuring
+/// `index * stride + 4 <= offset_bytes.len()`.
+#[inline]
+fn decode_offset(offset_bytes: &[u8], index: usize, stride: usize) -> u32 {
+	let base = index * stride;
+	u32::from_le_bytes([
+		offset_bytes[base],
+		offset_bytes[base + 1],
+		offset_bytes[base + 2],
+		offset_bytes[base + 3],
+	])
+}
+
 /// Validate an indexed-struct prologue: offsets must be strictly monotonic and
 /// the last offset must lie within `payload_len`.
+///
+/// `offset_bytes` is the raw `u32_le` offset table from the on-wire payload.
+/// `count` is the number of entries and `stride` is the byte distance between
+/// successive entries (4 for a contiguous offset table; 8 for an interleaved
+/// `(key_off, val_off)` map table). Decoding entries on demand instead of
+/// materialising a `Vec<u32>` avoids one allocation + copy per validation.
 #[doc(hidden)]
-pub fn validate_struct_prologue(offsets: &[u32], payload_len: u32) -> Result<(), Error> {
+pub fn validate_struct_prologue(
+	offset_bytes: &[u8],
+	count: usize,
+	stride: usize,
+	payload_len: u32,
+) -> Result<(), Error> {
 	let mut last: Option<u32> = None;
-	for &o in offsets {
+	for i in 0..count {
+		let o = decode_offset(offset_bytes, i, stride);
 		if o > payload_len {
 			return Err(Error::OptimisedOffsetOutOfRange {
 				offset: o,
@@ -30,33 +56,45 @@ pub fn validate_struct_prologue(offsets: &[u32], payload_len: u32) -> Result<(),
 }
 
 /// Validate the parallel key/value offset tables in an indexed-map prologue.
+///
+/// `offset_table` holds the interleaved `(u32_le key_off, u32_le val_off)`
+/// pairs (`count * 8` bytes); the key column lives at strides
+/// `0, 8, 16, …` and the value column at `4, 12, 20, …`.
 #[doc(hidden)]
 pub fn validate_map_prologue(
-	key_offsets: &[u32],
-	val_offsets: &[u32],
+	offset_table: &[u8],
+	count: usize,
 	keys_region_len: u32,
 	vals_region_len: u32,
 ) -> Result<(), Error> {
-	if key_offsets.len() != val_offsets.len() {
+	if offset_table.len() != count.saturating_mul(8) {
 		return Err(Error::OptimisedOffsetsNonMonotonic);
 	}
-	validate_struct_prologue(key_offsets, keys_region_len)?;
-	validate_struct_prologue(val_offsets, vals_region_len)?;
+	validate_struct_prologue(offset_table, count, 8, keys_region_len)?;
+	validate_struct_prologue(&offset_table[4..], count, 8, vals_region_len)?;
 	Ok(())
 }
 
 /// Validate that the dense keys region is strictly ascending by byte compare.
+///
+/// `offset_table` is the same interleaved byte slice passed to
+/// [`validate_map_prologue`]; this routine reads only the key column
+/// (stride 8) and slices each adjacent pair of keys from `keys_region` for
+/// comparison.
 #[doc(hidden)]
-pub fn validate_key_region_ascending(keys_region: &[u8], key_offsets: &[u32]) -> Result<(), Error> {
-	let len = key_offsets.len();
-	for i in 1..len {
-		let prev_start = key_offsets[i - 1] as usize;
-		let curr_start = key_offsets[i] as usize;
+pub fn validate_key_region_ascending(
+	keys_region: &[u8],
+	offset_table: &[u8],
+	count: usize,
+) -> Result<(), Error> {
+	for i in 1..count {
+		let prev_start = decode_offset(offset_table, i - 1, 8) as usize;
+		let curr_start = decode_offset(offset_table, i, 8) as usize;
 		// `validate_map_prologue` already enforced monotonicity, so curr_start > prev_start.
 		// Last entry runs to keys_region.len(); intermediate to next offset.
 		let prev_end = curr_start;
-		let curr_end = if i + 1 < len {
-			key_offsets[i + 1] as usize
+		let curr_end = if i + 1 < count {
+			decode_offset(offset_table, i + 1, 8) as usize
 		} else {
 			keys_region.len()
 		};
@@ -69,25 +107,56 @@ pub fn validate_key_region_ascending(keys_region: &[u8], key_offsets: &[u32]) ->
 	Ok(())
 }
 
-/// Validate an indexed-seq prologue: same shape as a struct prologue.
+/// Validate an indexed-seq prologue.
+///
+/// `elem_offset_bytes` is the contiguous `count * 4` byte offset table from
+/// the on-wire payload (stride = 4).
 #[doc(hidden)]
 #[inline]
-pub fn validate_seq_prologue(elem_offsets: &[u32], payload_len: u32) -> Result<(), Error> {
-	validate_struct_prologue(elem_offsets, payload_len)
+pub fn validate_seq_prologue(
+	elem_offset_bytes: &[u8],
+	count: usize,
+	payload_len: u32,
+) -> Result<(), Error> {
+	validate_struct_prologue(elem_offset_bytes, count, 4, payload_len)
 }
 
 #[cfg(test)]
 mod tests {
 	use super::*;
 
+	/// Pack a `&[u32]` into a contiguous `Vec<u8>` of `u32_le` entries
+	/// (stride = 4) for the validators' on-wire shape.
+	fn pack_offsets(offsets: &[u32]) -> Vec<u8> {
+		let mut out = Vec::with_capacity(offsets.len() * 4);
+		for &o in offsets {
+			out.extend_from_slice(&o.to_le_bytes());
+		}
+		out
+	}
+
+	/// Pack parallel `(key_off, val_off)` columns into the interleaved
+	/// stride-8 layout the map prologue expects.
+	fn pack_interleaved(key_offsets: &[u32], val_offsets: &[u32]) -> Vec<u8> {
+		assert_eq!(key_offsets.len(), val_offsets.len());
+		let mut out = Vec::with_capacity(key_offsets.len() * 8);
+		for (k, v) in key_offsets.iter().zip(val_offsets.iter()) {
+			out.extend_from_slice(&k.to_le_bytes());
+			out.extend_from_slice(&v.to_le_bytes());
+		}
+		out
+	}
+
 	#[test]
 	fn struct_prologue_accepts_monotonic_in_range() {
-		assert!(validate_struct_prologue(&[0, 4, 12, 20], 24).is_ok());
+		let bytes = pack_offsets(&[0, 4, 12, 20]);
+		assert!(validate_struct_prologue(&bytes, 4, 4, 24).is_ok());
 	}
 
 	#[test]
 	fn struct_prologue_rejects_out_of_range() {
-		let err = validate_struct_prologue(&[0, 4, 100], 50).unwrap_err();
+		let bytes = pack_offsets(&[0, 4, 100]);
+		let err = validate_struct_prologue(&bytes, 3, 4, 50).unwrap_err();
 		assert!(matches!(
 			err,
 			Error::OptimisedOffsetOutOfRange {
@@ -99,20 +168,25 @@ mod tests {
 
 	#[test]
 	fn struct_prologue_rejects_non_monotonic() {
+		let dup = pack_offsets(&[0, 4, 4, 8]);
 		assert!(matches!(
-			validate_struct_prologue(&[0, 4, 4, 8], 16).unwrap_err(),
+			validate_struct_prologue(&dup, 4, 4, 16).unwrap_err(),
 			Error::OptimisedOffsetsNonMonotonic
 		));
+		let desc = pack_offsets(&[8, 4]);
 		assert!(matches!(
-			validate_struct_prologue(&[8, 4], 16).unwrap_err(),
+			validate_struct_prologue(&desc, 2, 4, 16).unwrap_err(),
 			Error::OptimisedOffsetsNonMonotonic
 		));
 	}
 
 	#[test]
 	fn map_prologue_rejects_mismatched_lengths() {
+		// Caller passes a `count` that doesn't match the slice — must reject.
+		// Simulated by packing 2 pairs (16 bytes) but claiming count=3.
+		let bytes = pack_interleaved(&[0, 4], &[0, 4]);
 		assert!(matches!(
-			validate_map_prologue(&[0, 4], &[0, 4, 8], 8, 12).unwrap_err(),
+			validate_map_prologue(&bytes, 3, 8, 12).unwrap_err(),
 			Error::OptimisedOffsetsNonMonotonic
 		));
 	}
@@ -121,17 +195,17 @@ mod tests {
 	fn key_region_ascending_accepts_sorted() {
 		// keys: "a", "b", "c" packed contiguously
 		let keys = b"abc";
-		let offsets = [0u32, 1, 2];
-		assert!(validate_key_region_ascending(keys, &offsets).is_ok());
+		let table = pack_interleaved(&[0, 1, 2], &[0, 0, 0]);
+		assert!(validate_key_region_ascending(keys, &table, 3).is_ok());
 	}
 
 	#[test]
 	fn key_region_ascending_rejects_unsorted() {
 		// keys: "b", "a"
 		let keys = b"ba";
-		let offsets = [0u32, 1];
+		let table = pack_interleaved(&[0, 1], &[0, 0]);
 		assert!(matches!(
-			validate_key_region_ascending(keys, &offsets).unwrap_err(),
+			validate_key_region_ascending(keys, &table, 2).unwrap_err(),
 			Error::OptimisedKeyRegionNotAscending
 		));
 	}
@@ -139,20 +213,21 @@ mod tests {
 	#[test]
 	fn key_region_ascending_rejects_duplicates() {
 		let keys = b"aa";
-		let offsets = [0u32, 1];
+		let table = pack_interleaved(&[0, 1], &[0, 0]);
 		assert!(matches!(
-			validate_key_region_ascending(keys, &offsets).unwrap_err(),
+			validate_key_region_ascending(keys, &table, 2).unwrap_err(),
 			Error::OptimisedKeyRegionNotAscending
 		));
 	}
 
 	#[test]
 	fn key_region_ascending_handles_empty() {
-		assert!(validate_key_region_ascending(&[], &[]).is_ok());
+		assert!(validate_key_region_ascending(&[], &[], 0).is_ok());
 	}
 
 	#[test]
 	fn key_region_ascending_handles_single() {
-		assert!(validate_key_region_ascending(b"x", &[0]).is_ok());
+		let table = pack_interleaved(&[0], &[0]);
+		assert!(validate_key_region_ascending(b"x", &table, 1).is_ok());
 	}
 }


### PR DESCRIPTION
## Summary

- `IndexedSeqWalker` and `IndexedMapWalker` no longer allocate a `Vec<u32>` (or two, for maps) per `from_payload*` call — the offset table is borrowed directly from the payload as `&'p [u8]` and decoded on demand via `u32::from_le_bytes` on 4-byte windows.
- `IndexedMapWalker` keeps the interleaved on-wire shape as a single byte slice of `count * 8` bytes; key/value columns are accessed via stride-8 `MapPrologue::{key_off, val_off}`.
- `optimised::validation` validators were the only consumers of the old `&[u32]` shape; re-signed to `(offset_bytes, count, stride, payload_len)` so they walk the borrowed bytes directly.
- Public walker API surface is unchanged: `from_payload`, `from_payload_unvalidated`, `element_bytes`, `find_value_bytes`, `entries`, `is_indexed`, `len`, `legacy_body`, `body` — all same signatures.

## Why

The walker is on SurrealDB's scan/predicate hot path: opened per row per descent level inside the pre-decode filter. The `Vec<u32>` allocation + per-entry parse loop is unconditional and appeared as a real cost in production flame graphs.

A targeted profile of `IndexedMapWalker` construction (after independently bypassing a few unrelated overheads upstream) showed walker construction at ~4.5% of total CPU on scan-heavy workloads — almost all of it in `parse_offsets` allocating + copying a fresh `Vec<u32>`. For a 50-field row at 1M rows, that's ~100M heap allocations attributable to nothing but parsing the offset table.

The borrowed-slice form trades zero allocations for one `u32::from_le_bytes` per probe — essentially one aligned `mov` on common targets. Binary-search inner loops do `O(log N)` probes, not `O(N)`, so the on-demand decode cost is negligible compared to the eliminated allocation.

## Test plan

- [x] `cargo test` — all 190+ unit tests, 14 integration tests, doctests pass
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo fmt` — applied
- [x] End-to-end against SurrealDB via a temporary `[patch.crates-io]` override: 107 `pre_decode_filter` unit tests + 30 `object_extract` unit tests + 14 `predicate_pre_decode_filter_*.surql` language tests all pass
- [ ] Review the validation tests in `optimised/validation.rs` — the test helpers `pack_offsets` / `pack_interleaved` round-trip the old `&[u32]` test fixtures into the new on-wire shape so existing coverage is preserved