### PR TITLE
feat(walk): emit into_<field>_bytes(self) accessor for every struct field

### DIFF
--- a/revision-derive/src/expand/walk.rs
+++ b/revision-derive/src/expand/walk.rs
@@ -467,6 +467,7 @@ fn emit_struct_methods(
 		let skip_name = format_ident!("skip_{}", method_base);
 		let walk_name = format_ident!("walk_{}", method_base);
 		let into_walk_name = format_ident!("into_walk_{}", method_base);
+		let into_field_bytes_name = format_ident!("into_{}_bytes", method_base);
 		let ty = &f.ty;
 		let pos_lit = latest_idx as u32;
 
@@ -888,6 +889,126 @@ fn emit_struct_methods(
 			};
 		}
 
+		// `into_<field>_bytes(self) -> Cow<'r, [u8]>` — borrowed
+		// wire bytes for the field, without decoding the inner type.
+		//
+		// Lets callers construct a child walker themselves via
+		// `T::walk_revisioned(&mut bytes)`. The use case is
+		// `indexed_struct` types whose plain (non-`indexed_map` /
+		// `indexed_seq` / `indexed_set`) fields can't be reached via
+		// `into_walk_<field>` on an `IndexedBorrowed` parent — building
+		// the streaming child walker would require an owned reader the
+		// macro can't conjure. Returning bytes pushes that construction
+		// to the caller's scope, where the lifetime is well-defined.
+		//
+		// Three walker arms:
+		//
+		// - `IndexedBorrowed`: O(1) — slice `parent.bytes[offsets[i]
+		//   ..offsets[i+1]]`. Returns `Cow::Borrowed` at lifetime `'r`.
+		// - `Wire`: snapshot `reader.remaining()` before/after a skip
+		//   of the field; lifetime-extend the consumed slice via the
+		//   `BorrowedReader` contract (same unsafe pattern as
+		//   `read_borrowed_bytes`). Returns `Cow::Borrowed` at `'r`.
+		// - `ConvertedOwned`: decode the field from the parent's
+		//   materialised bytes, re-encode into a fresh `Vec<u8>`.
+		//   Returns `Cow::Owned`. Rare cross-rev `convert_fn` path.
+		let into_field_bytes_wire_rev_check = if always_present {
+			quote! {}
+		} else {
+			let bytes_err_msg = format!(
+				"into_{}_bytes not available at wire revision {{}}: field added at revision {}",
+				method_base, start_val,
+			);
+			quote! {
+				if wire_rev < #start_val {
+					return ::std::result::Result::Err(::revision::Error::Conversion(
+						::std::format!(#bytes_err_msg, wire_rev),
+					));
+				}
+			}
+		};
+		let into_field_bytes_body = quote! {
+			let mut __self = self;
+			// IndexedBorrowed fast path — borrow from the offset table.
+			if let #walker_repr_name::IndexedBorrowed { bytes, field_count, .. } = &__self.repr {
+				let __bytes_borrow: &'r [u8] = *bytes;
+				let __fc = *field_count as usize;
+				let __off_base = (#pos_lit as usize) * 4;
+				if __off_base + 4 > __bytes_borrow.len() {
+					return ::std::result::Result::Err(::revision::Error::Deserialize(
+						"IndexedBorrowed offset table truncated".into(),
+					));
+				}
+				let __start = u32::from_le_bytes(
+					__bytes_borrow[__off_base..__off_base + 4]
+						.try_into()
+						.expect("4-byte slice"),
+				) as usize;
+				let __end = if (#pos_lit as usize) + 1 < __fc {
+					u32::from_le_bytes(
+						__bytes_borrow[__off_base + 4..__off_base + 8]
+							.try_into()
+							.expect("4-byte slice"),
+					) as usize
+				} else {
+					__bytes_borrow.len()
+				};
+				return ::std::result::Result::Ok(
+					::std::borrow::Cow::Borrowed(&__bytes_borrow[__start..__end]),
+				);
+			}
+			// Wire / ConvertedOwned: consume `__self.repr`.
+			match __self.repr {
+				#walker_repr_name::Wire { reader, wire_rev, pos: _ } => {
+					#into_field_bytes_wire_rev_check
+					let __before = ::revision::BorrowedReader::remaining(reader);
+					let __before_ptr = __before.as_ptr();
+					let __before_len = __before.len();
+					#field_skip_call
+					let __after_len = ::revision::BorrowedReader::remaining(reader).len();
+					let __consumed_len = __before_len
+						.checked_sub(__after_len)
+						.ok_or_else(|| ::revision::Error::BorrowedReaderContractViolation(
+							::std::format!(
+								"remaining().len() grew across an advance call \
+								 (before={}, after={})",
+								__before_len,
+								__after_len,
+							)
+						))?;
+					// SAFETY: `BorrowedReader::remaining` returns a slice
+					// into the reader's stable buffer; the trait's safety
+					// contract guarantees `advance`/`skip` only moves the
+					// cursor and never invalidates previously-returned
+					// bytes, so `__before_ptr[..__consumed_len]` is valid
+					// for the reader's lifetime `'r`. `checked_sub` above
+					// guarantees the slice can never extend past the
+					// stable region. Mirrors `fast_path_wire` used by the
+					// indexed-field accessors.
+					let __field_bytes: &'r [u8] = unsafe {
+						::std::slice::from_raw_parts(__before_ptr, __consumed_len)
+					};
+					::std::result::Result::Ok(::std::borrow::Cow::Borrowed(__field_bytes))
+				}
+				#walker_repr_name::ConvertedOwned { bytes, cursor, pos: _, .. } => {
+					let mut __slice: &[u8] = &bytes[cursor..];
+					let __v = <#ty as ::revision::DeserializeRevisioned>::deserialize_revisioned(
+						&mut __slice,
+					)?;
+					let mut __out: ::std::vec::Vec<u8> = ::std::vec::Vec::new();
+					<#ty as ::revision::SerializeRevisioned>::serialize_revisioned(
+						&__v, &mut __out,
+					)?;
+					::std::result::Result::Ok(::std::borrow::Cow::Owned(__out))
+				}
+				#walker_repr_name::IndexedBorrowed { .. } => {
+					::std::unreachable!(
+						"IndexedBorrowed handled by the borrowed-bytes fast path above",
+					);
+				}
+			}
+		};
+
 		out.append_all(quote! {
 			/// Decode this field, advancing the walker.
 			///
@@ -997,6 +1118,41 @@ fn emit_struct_methods(
 				self,
 			) -> ::std::result::Result<#into_walk_return_ty, ::revision::Error> {
 				#into_walk_body
+			}
+
+			/// Borrow this field's wire bytes without decoding the inner type.
+			///
+			/// Consumes the parent walker and returns the field's raw wire
+			/// bytes as `Cow<'r, [u8]>`. Lets the caller construct a child
+			/// walker themselves via `T::walk_revisioned(&mut bytes)`.
+			///
+			/// Three walker arms:
+			///
+			/// - **`IndexedBorrowed`** (optimised + `indexed_struct`): O(1)
+			///   — slice straight from the field's `(offset, len)` in the
+			///   parent's payload. Returns `Cow::Borrowed` at the parent's
+			///   `'r` lifetime, zero allocation.
+			/// - **`Wire`**: snapshot `reader.remaining()` before and after
+			///   a skip of the field; lifetime-extend the consumed slice
+			///   via the [`BorrowedReader`](::revision::BorrowedReader)
+			///   contract. Returns `Cow::Borrowed` at `'r`, zero
+			///   allocation, O(field bytes) skip cost.
+			/// - **`ConvertedOwned`** (cross-rev `convert_fn` round-trip):
+			///   decode the field from the parent's owned bytes and
+			///   re-encode into a fresh `Vec<u8>`. Returns `Cow::Owned`.
+			///   One allocation per call; rare path.
+			///
+			/// Useful when an `indexed_struct` parent holds a field whose
+			/// inner type isn't itself an `indexed_*` container — the
+			/// `into_walk_<field>` accessor would error on the
+			/// `IndexedBorrowed` arm because the macro can't construct a
+			/// child walker without an owned reader. Returning bytes
+			/// instead pushes that construction to the caller's scope.
+			#[inline]
+			pub fn #into_field_bytes_name(
+				self,
+			) -> ::std::result::Result<::std::borrow::Cow<'r, [u8]>, ::revision::Error> {
+				#into_field_bytes_body
 			}
 		});
 	}

--- a/revision-derive/src/expand/walk.rs
+++ b/revision-derive/src/expand/walk.rs
@@ -928,13 +928,17 @@ fn emit_struct_methods(
 			}
 		};
 		let into_field_bytes_body = quote! {
-			let mut __self = self;
+			let __self = self;
 			// IndexedBorrowed fast path — borrow from the offset table.
 			if let #walker_repr_name::IndexedBorrowed { bytes, field_count, .. } = &__self.repr {
 				let __bytes_borrow: &'r [u8] = *bytes;
 				let __fc = *field_count as usize;
 				let __off_base = (#pos_lit as usize) * 4;
-				if __off_base + 4 > __bytes_borrow.len() {
+				// Bounds-check the offset table reads. The non-last-field
+				// branch reads two consecutive entries, so it needs 8
+				// bytes; the last-field branch only needs its own 4.
+				let __needed = if (#pos_lit as usize) + 1 < __fc { 8 } else { 4 };
+				if __off_base + __needed > __bytes_borrow.len() {
 					return ::std::result::Result::Err(::revision::Error::Deserialize(
 						"IndexedBorrowed offset table truncated".into(),
 					));
@@ -953,6 +957,14 @@ fn emit_struct_methods(
 				} else {
 					__bytes_borrow.len()
 				};
+				// Validate the slice bounds before indexing — a malformed
+				// payload with `start > end` or `end > len` would otherwise
+				// panic in the slice op.
+				if __start > __end || __end > __bytes_borrow.len() {
+					return ::std::result::Result::Err(::revision::Error::Deserialize(
+						"IndexedBorrowed field offsets out of range".into(),
+					));
+				}
 				return ::std::result::Result::Ok(
 					::std::borrow::Cow::Borrowed(&__bytes_borrow[__start..__end]),
 				);
@@ -1120,34 +1132,12 @@ fn emit_struct_methods(
 				#into_walk_body
 			}
 
-			/// Borrow this field's wire bytes without decoding the inner type.
-			///
-			/// Consumes the parent walker and returns the field's raw wire
-			/// bytes as `Cow<'r, [u8]>`. Lets the caller construct a child
-			/// walker themselves via `T::walk_revisioned(&mut bytes)`.
-			///
-			/// Three walker arms:
-			///
-			/// - **`IndexedBorrowed`** (optimised + `indexed_struct`): O(1)
-			///   — slice straight from the field's `(offset, len)` in the
-			///   parent's payload. Returns `Cow::Borrowed` at the parent's
-			///   `'r` lifetime, zero allocation.
-			/// - **`Wire`**: snapshot `reader.remaining()` before and after
-			///   a skip of the field; lifetime-extend the consumed slice
-			///   via the [`BorrowedReader`](::revision::BorrowedReader)
-			///   contract. Returns `Cow::Borrowed` at `'r`, zero
-			///   allocation, O(field bytes) skip cost.
-			/// - **`ConvertedOwned`** (cross-rev `convert_fn` round-trip):
-			///   decode the field from the parent's owned bytes and
-			///   re-encode into a fresh `Vec<u8>`. Returns `Cow::Owned`.
-			///   One allocation per call; rare path.
-			///
-			/// Useful when an `indexed_struct` parent holds a field whose
-			/// inner type isn't itself an `indexed_*` container — the
-			/// `into_walk_<field>` accessor would error on the
-			/// `IndexedBorrowed` arm because the macro can't construct a
-			/// child walker without an owned reader. Returning bytes
-			/// instead pushes that construction to the caller's scope.
+			/// Consume this walker and return the field's raw wire bytes
+			/// as `Cow<'r, [u8]>`, without decoding the inner type. Lets
+			/// the caller construct a child walker themselves via
+			/// `T::walk_revisioned(&mut bytes)`. Borrowed from the source
+			/// buffer for `IndexedBorrowed` / `Wire` walkers; allocated on
+			/// the rare `ConvertedOwned` (cross-rev `convert_fn`) path.
 			#[inline]
 			pub fn #into_field_bytes_name(
 				self,

--- a/tests/walker_optimised.rs
+++ b/tests/walker_optimised.rs
@@ -245,3 +245,132 @@ fn walker_decode_variant_errors_on_wrong_variant() {
 		other => panic!("expected Deserialize error, got {other:?}"),
 	}
 }
+
+// ---------------------------------------------------------------------------
+// `into_<field>_bytes` accessor — borrowed wire bytes without inner decode.
+//
+// This is the escape hatch for `indexed_struct` types whose plain (non-
+// `indexed_*`) fields can't be walked via `into_walk_<field>` on an
+// `IndexedBorrowed` parent. The caller takes the bytes and constructs a
+// child walker themselves (`T::walk_revisioned(&mut bytes)`).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn into_field_bytes_on_indexed_borrowed_round_trips() {
+	let v = IndexedStruct {
+		a: 11,
+		b: 22,
+		c: 33,
+	};
+	let bytes = revision::to_vec(&v).unwrap();
+	let mut r: &[u8] = &bytes;
+	let w = IndexedStruct::walk_revisioned(&mut r).unwrap();
+	// Take the middle field's bytes and decode them independently — the
+	// returned slice borrows from the original payload (`Cow::Borrowed`).
+	let b_bytes = w.into_b_bytes().unwrap();
+	let mut sub: &[u8] = &b_bytes;
+	let b: u32 =
+		<u32 as revision::DeserializeRevisioned>::deserialize_revisioned(&mut sub).unwrap();
+	assert_eq!(b, 22);
+}
+
+#[test]
+fn into_field_bytes_on_indexed_borrowed_handles_first_and_last_fields() {
+	let v = IndexedStruct {
+		a: 100,
+		b: 200,
+		c: 300,
+	};
+	let bytes = revision::to_vec(&v).unwrap();
+
+	// First field (offset table → bytes[0..4]).
+	{
+		let mut r: &[u8] = &bytes;
+		let w = IndexedStruct::walk_revisioned(&mut r).unwrap();
+		let a_bytes = w.into_a_bytes().unwrap();
+		let mut sub: &[u8] = &a_bytes;
+		let a: u32 =
+			<u32 as revision::DeserializeRevisioned>::deserialize_revisioned(&mut sub).unwrap();
+		assert_eq!(a, 100);
+	}
+	// Last field (extends to payload end — exercises the open-ended slice).
+	{
+		let mut r: &[u8] = &bytes;
+		let w = IndexedStruct::walk_revisioned(&mut r).unwrap();
+		let c_bytes = w.into_c_bytes().unwrap();
+		let mut sub: &[u8] = &c_bytes;
+		let c: u32 =
+			<u32 as revision::DeserializeRevisioned>::deserialize_revisioned(&mut sub).unwrap();
+		assert_eq!(c, 300);
+	}
+}
+
+#[test]
+fn into_field_bytes_on_wire_round_trips() {
+	// Optimised (no `indexed_struct`) — the walker enters the Wire arm
+	// rather than IndexedBorrowed, so the accessor goes through the
+	// remaining()-snapshot + skip-and-recover path.
+	let v = OptStruct {
+		a: 42,
+		b: 100,
+	};
+	let bytes = revision::to_vec(&v).unwrap();
+	let mut r: &[u8] = &bytes;
+	let w = OptStruct::walk_revisioned(&mut r).unwrap();
+	let a_bytes = w.into_a_bytes().unwrap();
+	// `a` is the first field — bytes should be exactly the u32_le encoding
+	// of `a` (4 bytes under the default codec).
+	let mut sub: &[u8] = &a_bytes;
+	let a: u32 =
+		<u32 as revision::DeserializeRevisioned>::deserialize_revisioned(&mut sub).unwrap();
+	assert_eq!(a, 42);
+	assert_eq!(sub.len(), 0, "into_a_bytes should return exactly the field's bytes");
+}
+
+#[test]
+fn into_field_bytes_on_wire_returns_borrowed_not_owned() {
+	// The Wire arm uses the `BorrowedReader` contract to lifetime-extend
+	// the consumed slice — verify we get `Cow::Borrowed` and not an
+	// allocated `Cow::Owned`.
+	let v = OptStruct {
+		a: 1,
+		b: 2,
+	};
+	let bytes = revision::to_vec(&v).unwrap();
+	let mut r: &[u8] = &bytes;
+	let w = OptStruct::walk_revisioned(&mut r).unwrap();
+	let a_bytes = w.into_a_bytes().unwrap();
+	assert!(matches!(a_bytes, std::borrow::Cow::Borrowed(_)));
+}
+
+#[test]
+fn into_field_bytes_on_indexed_borrowed_returns_borrowed_not_owned() {
+	let v = IndexedStruct {
+		a: 1,
+		b: 2,
+		c: 3,
+	};
+	let bytes = revision::to_vec(&v).unwrap();
+	let mut r: &[u8] = &bytes;
+	let w = IndexedStruct::walk_revisioned(&mut r).unwrap();
+	let b_bytes = w.into_b_bytes().unwrap();
+	assert!(matches!(b_bytes, std::borrow::Cow::Borrowed(_)));
+}
+
+#[test]
+fn into_field_bytes_works_on_mixed_history_at_optimised_rev() {
+	// `MixedHistory` is `revision(1), revision(2, optimised)` — the
+	// encoder emits rev 2 (Wire arm with envelope-skipped reader).
+	let v = MixedHistory {
+		a: 7,
+		b: 11,
+	};
+	let bytes = revision::to_vec(&v).unwrap();
+	let mut r: &[u8] = &bytes;
+	let w = MixedHistory::walk_revisioned(&mut r).unwrap();
+	let a_bytes = w.into_a_bytes().unwrap();
+	let mut sub: &[u8] = &a_bytes;
+	let a: u32 =
+		<u32 as revision::DeserializeRevisioned>::deserialize_revisioned(&mut sub).unwrap();
+	assert_eq!(a, 7);
+}

--- a/tests/walker_optimised.rs
+++ b/tests/walker_optimised.rs
@@ -358,6 +358,47 @@ fn into_field_bytes_on_indexed_borrowed_returns_borrowed_not_owned() {
 }
 
 #[test]
+fn into_field_bytes_errors_when_field_not_yet_introduced() {
+	// `GuardedField` is `revision(1), revision(2)` — field `b` is added at
+	// rev 2. Encoding a v1 shadow without `b` and walking it (wire_rev=1)
+	// must reject `into_b_bytes()` with the conversion error emitted by
+	// the macro's revision guard.
+	#[revisioned(revision(1), revision(2))]
+	struct GuardedField {
+		a: u32,
+		#[revision(start = 2, default_fn = "default_b")]
+		b: u32,
+	}
+	impl GuardedField {
+		fn default_b(_rev: u16) -> Result<u32, revision::Error> {
+			Ok(0)
+		}
+	}
+
+	#[revisioned(revision(1))]
+	struct ShadowV1 {
+		a: u32,
+	}
+
+	let bytes = revision::to_vec(&ShadowV1 {
+		a: 99,
+	})
+	.unwrap();
+	let mut r: &[u8] = &bytes;
+	let w = GuardedField::walk_revisioned(&mut r).unwrap();
+	let err = w.into_b_bytes().expect_err("b doesn't exist at wire rev 1 — must error");
+	match err {
+		revision::Error::Conversion(msg) => {
+			assert!(
+				msg.contains("into_b_bytes") && msg.contains("wire revision 1"),
+				"unexpected guard message: {msg}",
+			);
+		}
+		other => panic!("expected Conversion error, got {other:?}"),
+	}
+}
+
+#[test]
 fn into_field_bytes_works_on_mixed_history_at_optimised_rev() {
 	// `MixedHistory` is `revision(1), revision(2, optimised)` — the
 	// encoder emits rev 2 (Wire arm with envelope-skipped reader).


### PR DESCRIPTION
## Summary

Adds a new per-field accessor on the macro-generated walker:

```rust
pub fn into_<field>_bytes(self) -> Result<Cow<'r, [u8]>, Error>
```

Returns the field's raw wire bytes without decoding the inner type. Lets callers construct a child walker themselves via `T::walk_revisioned(&mut bytes)`.

## Why

This is the escape hatch for `indexed_struct` types whose plain (non-`indexed_map` / `indexed_seq` / `indexed_set`) fields can't be reached via `into_walk_<field>` on an `IndexedBorrowed` parent. The macro currently errors there:

```rust
WalkerRepr::IndexedBorrowed { .. } => {
    Err(Error::Conversion(
        "into_walk_<field> is not supported on borrowed-bytes walkers; use decode_<field>".into(),
    ))
}
```

…because building a streaming child walker would require an owned reader the walker repr doesn't support. Returning bytes instead pushes that construction to the caller's scope, where the lifetime is well-defined.

Real-world driver: SurrealDB's pre-decode filter wants O(1) access to a `Record { metadata, data }`'s `data` field on an `indexed_struct` Record, then a streaming `Value::walk_revisioned` over those bytes. Right now SurrealDB hand-rolls the envelope parse (parses the `u32_le payload_length`, reads the prologue, slices to the field bytes). With this PR the same call becomes one method invocation.

## Three walker arms

Mirrors the existing `walk_<indexed_field>` fast-path patterns:

- **\`IndexedBorrowed\`** (optimised + \`indexed_struct\`): O(1) — read the field's \`(offset, offset+1)\` from the prologue, slice \`payload[start..end]\`, return \`Cow::Borrowed\` at the parent's \`'r\` lifetime. Zero allocation.
- **\`Wire\`** (sequential optimised or current-rev legacy): snapshot \`reader.remaining()\` before and after the field's \`SkipRevisioned\` call, lifetime-extend the consumed slice via the \`BorrowedReader\` contract (same \`unsafe\` pattern as \`read_borrowed_bytes\` and \`fast_path_wire\`). Returns \`Cow::Borrowed\` at \`'r\`. Zero allocation, O(field bytes) skip.
- **\`ConvertedOwned\`** (cross-rev \`convert_fn\` round-trip): decode the field from the parent's owned bytes, re-encode into a fresh \`Vec<u8>\`. Returns \`Cow::Owned\`. One allocation per call; rare path.

Field-not-yet-introduced revision-guard applies to Wire parents only; `IndexedBorrowed` / `ConvertedOwned` are always at the current revision where the field exists.

## Emitted for all fields

The accessor is emitted for **every** struct field — indexed and non-indexed alike — for API uniformity. For `indexed_*` fields the returned bytes are the serialized container shape (consumable by `IndexedMapWalker::from_payload` etc.); for plain fields they're the inner type's revisioned wire form (consumable by `T::walk_revisioned`).

## API impact

Strictly additive. No existing methods change shape. No wire-format change. Downstream:

- Existing code keeps working unchanged.
- Consumers using `indexed_struct` with plain non-indexed fields gain a usable walker-side path that didn't exist before.
- SurrealDB-core can simplify the hand-rolled \`rev2_record_data_field_bytes_unchecked\` helper to a one-line \`record_walker.into_data_bytes()?\` once it picks up this version.

## Test plan

- [x] All 18 existing test groups pass (340+ tests)
- [x] 6 new tests in `tests/walker_optimised.rs`:
  - \`into_field_bytes_on_indexed_borrowed_round_trips\` — middle field of a 3-field \`IndexedStruct\`
  - \`into_field_bytes_on_indexed_borrowed_handles_first_and_last_fields\` — offset-table edges
  - \`into_field_bytes_on_wire_round_trips\` — Wire-arm path with exact byte-count assertion
  - \`into_field_bytes_on_wire_returns_borrowed_not_owned\` — proves zero-alloc
  - \`into_field_bytes_on_indexed_borrowed_returns_borrowed_not_owned\` — same for IndexedBorrowed
  - \`into_field_bytes_works_on_mixed_history_at_optimised_rev\` — \`revision(1), revision(2, optimised)\` to cover envelope-skip path
- [x] \`cargo clippy --all-targets\` clean
- [x] \`cargo fmt\` applied
- [ ] \`ConvertedOwned\` arm — not directly tested in this PR; shape mirrors the existing \`walk_<indexed_field>\` ConvertedOwned arm. Would need a \`convert_fn\` fixture for direct coverage — out of scope here.