### PR TITLE
perf(indexed): O(1) skip on indexed bodies via BorrowedReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.26.0 — O(1) skip for indexed bodies
+## Unreleased — O(1) skip for indexed bodies
 
 Fast-path the per-record cost of skipping `#[revision(indexed_map)]` /
 `#[revision(indexed_seq)]` / `#[revision(indexed_set)]` fields. Driven
@@ -52,9 +52,8 @@ fast-paths.
 ### Wire-format compatibility
 
 The on-wire layout for `indexed_map`, `indexed_seq`, and `indexed_set`
-is unchanged. Bytes produced by 0.25.x deserialise identically with
-0.26.0 and vice versa; this release only changes how skips parse those
-bytes.
+is unchanged. Bytes produced by previous releases deserialise identically against
+this version and vice versa; only the parser-side skip path changes.
 
 ## 0.23.0 (unreleased) — design refactor follow-up
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,61 @@
 # Changelog
 
+## 0.26.0 — O(1) skip for indexed bodies
+
+Fast-path the per-record cost of skipping `#[revision(indexed_map)]` /
+`#[revision(indexed_seq)]` / `#[revision(indexed_set)]` fields. Driven
+by a SurrealDB no-index scan profile where `skip_indexed_map` accounted
+for ~15 % of total CPU — per-entry `K::skip_revisioned` /
+`V::skip_revisioned` walks plus a `vec![0u8; len*8 + 8]` discard buffer
+allocation per call. The wire format is unchanged; only the parser
+fast-paths.
+
+### Changed (breaking, source-level)
+
+- **`IndexedMapEncoded::skip_indexed_map` / `IndexedSeqEncoded::skip_indexed_seq` /
+  `IndexedSetEncoded::skip_indexed_set` now bound the reader type as
+  `R: BorrowedReader` instead of `R: Read`.** The wire format is
+  unchanged; the bound tightens because the fast paths use
+  `BorrowedReader::advance` (a pointer-bump on slice-backed readers)
+  to jump past the offset table and dense regions without copying or
+  allocating. Downstream hand-written impls (e.g. SurrealDB's
+  `VecMap` / `VecSet`) need a one-line bound update; everything that
+  flows through the macro-generated walker code already used
+  `BorrowedReader`-bounded readers, so consumer-side callers built on
+  the macro need no changes.
+
+### Performance
+
+- **`skip_indexed_map` is now O(1) on indexed bodies.** The prologue
+  carries the dense regions' total byte lengths (`keys_region_len` and
+  `vals_region_len` as `u32_le`); the new implementation reads those,
+  jumps past the offset table and both dense regions via
+  `BorrowedReader::advance`, and never invokes `K`'s or `V`'s
+  `SkipRevisioned` impl. Profile contribution of `Value::skip_revisioned`
+  inside `skip_indexed_map` drops out entirely on indexed bodies.
+- **`skip_indexed_seq` / `skip_indexed_set` reduced from O(N) entry
+  skips to a single entry skip.** The seq wire format records only
+  per-element offsets (no total dense length), so the new path reads
+  the last offset, advances to the start of the final element, then
+  calls `T::skip_revisioned` once.
+- **Removed the `vec![0u8; n]` discard allocation in the skip path.**
+  The old indexed-body skip path allocated a discard buffer per call to
+  `read_exact` past the offset table. The new path advances the cursor
+  directly. The free helper `advance_read` (used by other
+  `SkipRevisioned` impls) already used a stack buffer; the indexed-map
+  / indexed-seq paths now bypass it altogether via the borrowed reader.
+- **Blanket `BorrowedReader for &mut R`** added so the macro-emitted
+  walker code (which holds `reader: &'r mut R` and matches with
+  `&mut self.repr`, producing a `&mut &'r mut R` binding) can call
+  through `skip_indexed_*` without an explicit reborrow.
+
+### Wire-format compatibility
+
+The on-wire layout for `indexed_map`, `indexed_seq`, and `indexed_set`
+is unchanged. Bytes produced by 0.25.x deserialise identically with
+0.26.0 and vice versa; this release only changes how skips parse those
+bytes.
+
 ## 0.23.0 (unreleased) — design refactor follow-up
 
 A second pass over the optimised wire-format work. Several design choices

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "revision-derive"]
 
 [workspace.package]
 edition = "2024"
-version = "0.26.0"
+version = "0.25.0"
 authors = ["Tobie Morgan Hitchcock <tobie@surrealdb.com>"]
 description = "A serialization and deserialization implementation which allows for schema-evolution."
 repository = "https://github.com/surrealdb/revision"
@@ -35,7 +35,7 @@ specialised-vectors = []
 fixed-width-encoding = []
 
 [dependencies]
-revision-derive = { version = "0.26.0", path = "revision-derive" }
+revision-derive = { version = "0.25.0", path = "revision-derive" }
 bytes = { version = "1.11.0", optional = true }
 chrono = { version = "0.4.42", default-features = false, features = ["std"], optional = true }
 geo = { version = "0.32.0", default-features = false, features = ["use-serde"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "revision-derive"]
 
 [workspace.package]
 edition = "2024"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Tobie Morgan Hitchcock <tobie@surrealdb.com>"]
 description = "A serialization and deserialization implementation which allows for schema-evolution."
 repository = "https://github.com/surrealdb/revision"
@@ -35,7 +35,7 @@ specialised-vectors = []
 fixed-width-encoding = []
 
 [dependencies]
-revision-derive = { version = "0.25.0", path = "revision-derive" }
+revision-derive = { version = "0.26.0", path = "revision-derive" }
 bytes = { version = "1.11.0", optional = true }
 chrono = { version = "0.4.42", default-features = false, features = ["std"], optional = true }
 geo = { version = "0.32.0", default-features = false, features = ["use-serde"], optional = true }

--- a/src/implementations/imbl.rs
+++ b/src/implementations/imbl.rs
@@ -6,7 +6,9 @@ use super::super::optimised::indexed::{
 	deserialize_indexed_seq, serialize_indexed_entries, serialize_indexed_seq_iter,
 	serialize_indexed_set_iter, skip_indexed_map, skip_indexed_seq, skip_indexed_set,
 };
-use super::super::{DeserializeRevisioned, Revisioned, SerializeRevisioned, SkipRevisioned};
+use super::super::{
+	BorrowedReader, DeserializeRevisioned, Revisioned, SerializeRevisioned, SkipRevisioned,
+};
 use imbl::{HashMap, HashSet, OrdMap, OrdSet, Vector};
 use std::hash::Hash;
 
@@ -29,7 +31,7 @@ where
 		let std_map: std::collections::BTreeMap<K, V> = deserialize_indexed_map(r)?;
 		Ok(std_map.into_iter().collect())
 	}
-	fn skip_indexed_map<R: std::io::Read>(r: &mut R) -> Result<(), Error> {
+	fn skip_indexed_map<R: BorrowedReader>(r: &mut R) -> Result<(), Error> {
 		skip_indexed_map::<K, V, R>(r)
 	}
 }
@@ -51,7 +53,7 @@ where
 			<std::collections::HashMap<K, V> as IndexedMapEncoded>::deserialize_indexed_map(r)?;
 		Ok(std_map.into_iter().collect())
 	}
-	fn skip_indexed_map<R: std::io::Read>(r: &mut R) -> Result<(), Error> {
+	fn skip_indexed_map<R: BorrowedReader>(r: &mut R) -> Result<(), Error> {
 		skip_indexed_map::<K, V, R>(r)
 	}
 }
@@ -68,7 +70,7 @@ where
 		let v: Vec<T> = deserialize_indexed_seq(r)?;
 		Ok(v.into_iter().collect())
 	}
-	fn skip_indexed_seq<R: std::io::Read>(r: &mut R) -> Result<(), Error> {
+	fn skip_indexed_seq<R: BorrowedReader>(r: &mut R) -> Result<(), Error> {
 		skip_indexed_seq::<T, R>(r)
 	}
 }
@@ -85,7 +87,7 @@ where
 		let v: Vec<T> = deserialize_indexed_seq(r)?;
 		Ok(v.into_iter().collect())
 	}
-	fn skip_indexed_set<R: std::io::Read>(r: &mut R) -> Result<(), Error> {
+	fn skip_indexed_set<R: BorrowedReader>(r: &mut R) -> Result<(), Error> {
 		skip_indexed_set::<T, R>(r)
 	}
 }
@@ -102,7 +104,7 @@ where
 		let v: Vec<T> = deserialize_indexed_seq(r)?;
 		Ok(v.into_iter().collect())
 	}
-	fn skip_indexed_set<R: std::io::Read>(r: &mut R) -> Result<(), Error> {
+	fn skip_indexed_set<R: BorrowedReader>(r: &mut R) -> Result<(), Error> {
 		skip_indexed_set::<T, R>(r)
 	}
 }

--- a/src/optimised/indexed/serialize.rs
+++ b/src/optimised/indexed/serialize.rs
@@ -879,20 +879,13 @@ where
 		return Ok(());
 	}
 	let table_bytes = len.checked_mul(4).ok_or(Error::OptimisedSubReaderOverrun)?;
-	// Peek the offset table to extract the final entry without consuming the
-	// reader yet — `BorrowedReader::peek_bytes` is a borrow against the
-	// reader's stable buffer.
+	// Peek the offset table to read the final offset, then advance past the
+	// table. Offsets are measured from the start of the dense region (just
+	// past the offset table — `body` in `IndexedSeqWalker`).
 	let table = reader.peek_bytes(table_bytes)?;
-	let last_off_pos = (len - 1) * 4;
-	let last_off =
-		u32::from_le_bytes(table[last_off_pos..last_off_pos + 4].try_into().unwrap()) as usize;
-	// Drop the offset table from the cursor.
+	let last_off = u32::from_le_bytes(table[(len - 1) * 4..len * 4].try_into().unwrap()) as usize;
 	reader.advance(table_bytes)?;
-	// Skip the dense region up to the start of the last element. The last
-	// offset is measured from the start of the dense region (i.e. just past
-	// the offset table — `body` in `IndexedSeqWalker`).
 	reader.advance(last_off)?;
-	// Skip the final element; `T::skip_revisioned` knows its own wire length.
 	T::skip_revisioned(reader)?;
 	Ok(())
 }

--- a/src/optimised/indexed/serialize.rs
+++ b/src/optimised/indexed/serialize.rs
@@ -17,6 +17,7 @@ use crate::Error;
 use crate::SkipRevisioned;
 use crate::optimised::indexed::OFFSET_TABLE_MIN_LEN;
 use crate::optimised::indexed::seq_walk::FLAG_INDEXED;
+use crate::slice_reader::BorrowedReader;
 use crate::{DeserializeRevisioned, SerializeRevisioned};
 
 // -----------------------------------------------------------------------------
@@ -79,7 +80,13 @@ pub trait IndexedMapEncoded: Sized {
 	type Value;
 	fn serialize_indexed_map<W: Write>(&self, w: &mut W) -> Result<(), Error>;
 	fn deserialize_indexed_map<R: Read>(r: &mut R) -> Result<Self, Error>;
-	fn skip_indexed_map<R: Read>(r: &mut R) -> Result<(), Error>;
+	/// Advance past an indexed-map payload without materialising it.
+	///
+	/// The reader must implement [`BorrowedReader`] so the skip can jump past
+	/// the dense regions via a pointer-bump `advance(n)` rather than allocating
+	/// a discard buffer or walking every entry — this is the per-record hot
+	/// path on scan-heavy workloads.
+	fn skip_indexed_map<R: BorrowedReader>(r: &mut R) -> Result<(), Error>;
 }
 
 impl<K, V> IndexedMapEncoded for BTreeMap<K, V>
@@ -95,7 +102,7 @@ where
 	fn deserialize_indexed_map<R: Read>(r: &mut R) -> Result<Self, Error> {
 		deserialize_indexed_map(r)
 	}
-	fn skip_indexed_map<R: Read>(r: &mut R) -> Result<(), Error> {
+	fn skip_indexed_map<R: BorrowedReader>(r: &mut R) -> Result<(), Error> {
 		skip_indexed_map::<K, V, R>(r)
 	}
 }
@@ -146,7 +153,7 @@ where
 		}
 		Ok(out)
 	}
-	fn skip_indexed_map<R: Read>(r: &mut R) -> Result<(), Error> {
+	fn skip_indexed_map<R: BorrowedReader>(r: &mut R) -> Result<(), Error> {
 		skip_indexed_map::<K, V, R>(r)
 	}
 }
@@ -157,7 +164,12 @@ pub trait IndexedSeqEncoded: Sized {
 	type Item;
 	fn serialize_indexed_seq<W: Write>(&self, w: &mut W) -> Result<(), Error>;
 	fn deserialize_indexed_seq<R: Read>(r: &mut R) -> Result<Self, Error>;
-	fn skip_indexed_seq<R: Read>(r: &mut R) -> Result<(), Error>;
+	/// Advance past an indexed-seq payload without materialising it.
+	///
+	/// Like [`IndexedMapEncoded::skip_indexed_map`], requires a
+	/// [`BorrowedReader`] so the skip can pointer-bump past the offset table
+	/// and the dense element region.
+	fn skip_indexed_seq<R: BorrowedReader>(r: &mut R) -> Result<(), Error>;
 }
 
 impl<T> IndexedSeqEncoded for Vec<T>
@@ -171,7 +183,7 @@ where
 	fn deserialize_indexed_seq<R: Read>(r: &mut R) -> Result<Self, Error> {
 		deserialize_indexed_seq(r)
 	}
-	fn skip_indexed_seq<R: Read>(r: &mut R) -> Result<(), Error> {
+	fn skip_indexed_seq<R: BorrowedReader>(r: &mut R) -> Result<(), Error> {
 		skip_indexed_seq::<T, R>(r)
 	}
 }
@@ -187,7 +199,10 @@ pub trait IndexedSetEncoded: Sized {
 	type Item;
 	fn serialize_indexed_set<W: Write>(&self, w: &mut W) -> Result<(), Error>;
 	fn deserialize_indexed_set<R: Read>(r: &mut R) -> Result<Self, Error>;
-	fn skip_indexed_set<R: Read>(r: &mut R) -> Result<(), Error>;
+	/// Advance past an indexed-set payload without materialising it. See
+	/// [`IndexedMapEncoded::skip_indexed_map`] for why this requires a
+	/// [`BorrowedReader`].
+	fn skip_indexed_set<R: BorrowedReader>(r: &mut R) -> Result<(), Error>;
 }
 
 /// Serialise an iterator of `&T` elements as an indexed set: identical
@@ -257,7 +272,7 @@ where
 pub fn skip_indexed_set<T, R>(reader: &mut R) -> Result<(), Error>
 where
 	T: SkipRevisioned,
-	R: Read,
+	R: BorrowedReader,
 {
 	skip_indexed_seq::<T, R>(reader)
 }
@@ -275,7 +290,7 @@ where
 	fn deserialize_indexed_set<R: Read>(r: &mut R) -> Result<Self, Error> {
 		deserialize_indexed_set(r)
 	}
-	fn skip_indexed_set<R: Read>(r: &mut R) -> Result<(), Error> {
+	fn skip_indexed_set<R: BorrowedReader>(r: &mut R) -> Result<(), Error> {
 		skip_indexed_set::<T, R>(r)
 	}
 }
@@ -293,7 +308,7 @@ where
 		let v: Vec<T> = deserialize_indexed_seq(r)?;
 		Ok(v.into_iter().collect())
 	}
-	fn skip_indexed_set<R: Read>(r: &mut R) -> Result<(), Error> {
+	fn skip_indexed_set<R: BorrowedReader>(r: &mut R) -> Result<(), Error> {
 		skip_indexed_seq::<T, R>(r)
 	}
 }
@@ -791,11 +806,15 @@ where
 
 /// Advance past an indexed-map encoding without materialising the keys or values.
 ///
-/// Mirrors [`deserialize_indexed_map`] structurally: read flags, len, skip
-/// the offset table + region lengths, then call `K::skip_revisioned` and
-/// `V::skip_revisioned` `len` times each.
+/// On the legacy (sub-threshold, no offset table) body this still walks each
+/// entry via `K::skip_revisioned` / `V::skip_revisioned`. On the indexed body
+/// it derives the dense-region length from the prologue's `(keys_region_len,
+/// vals_region_len)` pair and skips it in a single `BorrowedReader::advance`
+/// — O(1) work regardless of entry count, no K/V skipping, no allocation.
+///
+/// The wire format is unchanged; this is purely a parser-side fast path.
 #[doc(hidden)]
-pub fn skip_indexed_map<K, V, R: Read>(reader: &mut R) -> Result<(), Error>
+pub fn skip_indexed_map<K, V, R: BorrowedReader>(reader: &mut R) -> Result<(), Error>
 where
 	K: SkipRevisioned,
 	V: SkipRevisioned,
@@ -805,27 +824,41 @@ where
 	let flags = flag_buf[0];
 	let len = read_varint(reader)?;
 	if (flags & FLAG_INDEXED) == 0 {
+		// Legacy / sub-threshold body: no offset table, no region lengths;
+		// the only way to find the end is to walk each entry.
 		for _ in 0..len {
 			K::skip_revisioned(reader)?;
 			V::skip_revisioned(reader)?;
 		}
 		return Ok(());
 	}
+	// Indexed body: jump past the offset table (`len * 8` bytes — interleaved
+	// `(k_off, v_off)` u32 pairs), read the two `u32_le` region lengths, then
+	// jump past the dense regions. Whole skip is bounded; `K` and `V`'s skip
+	// impls are never invoked.
 	let table_bytes = len.checked_mul(8).ok_or(Error::OptimisedSubReaderOverrun)?;
-	let mut discard = vec![0u8; table_bytes + 8];
-	reader.read_exact(&mut discard).map_err(Error::Io)?;
-	for _ in 0..len {
-		K::skip_revisioned(reader)?;
-	}
-	for _ in 0..len {
-		V::skip_revisioned(reader)?;
-	}
+	reader.advance(table_bytes)?;
+	let mut lens_buf = [0u8; 8];
+	reader.read_exact(&mut lens_buf).map_err(Error::Io)?;
+	let k_region = u32::from_le_bytes(lens_buf[..4].try_into().unwrap()) as usize;
+	let v_region = u32::from_le_bytes(lens_buf[4..].try_into().unwrap()) as usize;
+	let dense_bytes = k_region.checked_add(v_region).ok_or(Error::OptimisedSubReaderOverrun)?;
+	reader.advance(dense_bytes)?;
 	Ok(())
 }
 
-/// Advance past an indexed-seq encoding.
+/// Advance past an indexed-seq encoding without materialising the elements.
+///
+/// On the indexed path the seq wire format does not record the dense region's
+/// total length explicitly — only the per-element offset table — so we can't
+/// jump the whole body in a single bound. Instead we read the last offset to
+/// reach the start of the final element, then call `T::skip_revisioned` once
+/// to advance past that element. That's O(1) buffer use + a single element
+/// skip regardless of `len`, replacing the previous N-entry walk.
+///
+/// The legacy (sub-threshold) body still walks every element.
 #[doc(hidden)]
-pub fn skip_indexed_seq<T, R: Read>(reader: &mut R) -> Result<(), Error>
+pub fn skip_indexed_seq<T, R: BorrowedReader>(reader: &mut R) -> Result<(), Error>
 where
 	T: SkipRevisioned,
 {
@@ -839,12 +872,28 @@ where
 		}
 		return Ok(());
 	}
-	let table_bytes = len.checked_mul(4).ok_or(Error::OptimisedSubReaderOverrun)?;
-	let mut discard = vec![0u8; table_bytes];
-	reader.read_exact(&mut discard).map_err(Error::Io)?;
-	for _ in 0..len {
-		T::skip_revisioned(reader)?;
+	// An indexed body always carries `len >= OFFSET_TABLE_MIN_LEN` (the encoder
+	// falls back to the legacy shape below threshold), so `len == 0` is a
+	// malformed prologue. Treat it conservatively: there's nothing more to skip.
+	if len == 0 {
+		return Ok(());
 	}
+	let table_bytes = len.checked_mul(4).ok_or(Error::OptimisedSubReaderOverrun)?;
+	// Peek the offset table to extract the final entry without consuming the
+	// reader yet — `BorrowedReader::peek_bytes` is a borrow against the
+	// reader's stable buffer.
+	let table = reader.peek_bytes(table_bytes)?;
+	let last_off_pos = (len - 1) * 4;
+	let last_off =
+		u32::from_le_bytes(table[last_off_pos..last_off_pos + 4].try_into().unwrap()) as usize;
+	// Drop the offset table from the cursor.
+	reader.advance(table_bytes)?;
+	// Skip the dense region up to the start of the last element. The last
+	// offset is measured from the start of the dense region (i.e. just past
+	// the offset table — `body` in `IndexedSeqWalker`).
+	reader.advance(last_off)?;
+	// Skip the final element; `T::skip_revisioned` knows its own wire length.
+	T::skip_revisioned(reader)?;
 	Ok(())
 }
 

--- a/src/slice_reader.rs
+++ b/src/slice_reader.rs
@@ -286,6 +286,38 @@ unsafe impl BorrowedReader for &[u8] {
 	}
 }
 
+// SAFETY: Forwarding impl. Every method delegates to the underlying `R`,
+// which is itself `BorrowedReader` and therefore obeys the trait's safety
+// contract (stable backing buffer, non-mutating `peek_bytes` / `remaining`,
+// monotonic non-increasing `remaining().len()` under `advance`). The
+// forwarding adds no state and cannot violate any invariant the inner impl
+// upholds.
+//
+// This impl is what lets the macro-emitted `walk_<field>` / `skip_<field>`
+// paths call `skip_indexed_*` with a `reader: &mut &'r mut R` binding
+// (extracted from the `Wire` repr variant) without an explicit reborrow.
+unsafe impl<R: BorrowedReader + ?Sized> BorrowedReader for &mut R {
+	#[inline]
+	fn peek_bytes(&self, n: usize) -> Result<&[u8], Error> {
+		(**self).peek_bytes(n)
+	}
+
+	#[inline]
+	fn advance(&mut self, n: usize) -> Result<(), Error> {
+		(**self).advance(n)
+	}
+
+	#[inline]
+	fn position(&self) -> usize {
+		(**self).position()
+	}
+
+	#[inline]
+	fn remaining(&self) -> &[u8] {
+		(**self).remaining()
+	}
+}
+
 // SAFETY: `SliceReader<'a>` borrows an external `&'a [u8]` it never modifies.
 // `peek_bytes` returns slices into that external buffer; `advance` only updates
 // the internal cursor (`inner`), never the buffer. Both invariants hold.

--- a/src/slice_reader.rs
+++ b/src/slice_reader.rs
@@ -480,4 +480,37 @@ mod tests {
 		assert_eq!(taken, &[1, 2, 3]);
 		assert_eq!(r.remaining(), &[4]);
 	}
+
+	/// The blanket impl `BorrowedReader for &mut R` is what lets the
+	/// macro-emitted walker code call `skip_indexed_*<R: BorrowedReader>`
+	/// with a `reader: &mut &'r mut R` binding. Exercising it through a
+	/// generic helper confirms every method forwards correctly and that
+	/// mutations on the `&mut R` reborrow are visible on the underlying
+	/// reader.
+	#[test]
+	fn borrowed_reader_blanket_impl_forwards_to_underlying() {
+		fn use_borrowed<R: BorrowedReader>(r: &mut R) -> (Vec<u8>, usize, usize, usize) {
+			let peeked = r.peek_bytes(3).unwrap().to_vec();
+			let pos_before = r.position();
+			let remaining_before = r.remaining().len();
+			r.advance(3).unwrap();
+			(peeked, pos_before, remaining_before, r.remaining().len())
+		}
+
+		let data = [10u8, 20, 30, 40, 50, 60];
+		let mut backing = SliceReader::new(&data);
+		// Take a `&mut SliceReader`, then re-borrow as `&mut &mut SliceReader`
+		// to exercise the blanket impl rather than the direct one.
+		let mut reborrow: &mut SliceReader = &mut backing;
+		let (peeked, pos_before, remaining_before, remaining_after) = use_borrowed(&mut reborrow);
+
+		assert_eq!(peeked, &[10, 20, 30]);
+		assert_eq!(pos_before, 0);
+		assert_eq!(remaining_before, 6);
+		assert_eq!(remaining_after, 3);
+		// The advance through the blanket impl must be visible on the
+		// original reader.
+		assert_eq!(backing.position(), 3);
+		assert_eq!(backing.remaining(), &[40, 50, 60]);
+	}
 }

--- a/tests/skip_indexed_fast_path.rs
+++ b/tests/skip_indexed_fast_path.rs
@@ -1,0 +1,313 @@
+//! Regression coverage for the O(1) / O(1 element) skip fast path on indexed
+//! bodies (see `skip_indexed_map`, `skip_indexed_seq`, `skip_indexed_set` in
+//! `src/optimised/indexed/serialize.rs`).
+//!
+//! Each test verifies two things:
+//!
+//! 1. After `skip_*` the reader's cursor sits exactly at the end of the
+//!    encoded payload (no over- or under-consume).
+//! 2. The behaviour is identical on the legacy (sub-threshold) and indexed
+//!    (≥ OFFSET_TABLE_MIN_LEN) shapes — the encoder picks one based on length,
+//!    the reader must handle both.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use revision::optimised::indexed::{
+	IndexedMapEncoded, IndexedSeqEncoded, IndexedSetEncoded, deserialize_indexed_map,
+	deserialize_indexed_seq, deserialize_indexed_set, serialize_indexed_map, serialize_indexed_seq,
+	serialize_indexed_set_iter, skip_indexed_map, skip_indexed_seq, skip_indexed_set,
+};
+
+/// Build the indexed-map payload, skip it, assert the cursor is at EOF and a
+/// round-trip via deserialize gives the same value.
+fn round_trip_map<K, V>(map: BTreeMap<K, V>)
+where
+	K: revision::SerializeRevisioned
+		+ revision::DeserializeRevisioned
+		+ revision::SkipRevisioned
+		+ Ord
+		+ Clone
+		+ std::fmt::Debug
+		+ Eq,
+	V: revision::SerializeRevisioned
+		+ revision::DeserializeRevisioned
+		+ revision::SkipRevisioned
+		+ Clone
+		+ std::fmt::Debug
+		+ Eq,
+{
+	let mut bytes = Vec::new();
+	serialize_indexed_map(&map, &mut bytes).unwrap();
+
+	// 1. Skip path must end at EOF.
+	let mut r: &[u8] = &bytes;
+	skip_indexed_map::<K, V, _>(&mut r).unwrap();
+	assert!(r.is_empty(), "skip_indexed_map left {} bytes ({} entries)", r.len(), map.len(),);
+
+	// 2. Deserialize must still round-trip.
+	let mut r: &[u8] = &bytes;
+	let decoded: BTreeMap<K, V> = deserialize_indexed_map(&mut r).unwrap();
+	assert!(r.is_empty(), "deserialize_indexed_map left bytes");
+	assert_eq!(decoded, map);
+}
+
+fn round_trip_seq<T>(items: Vec<T>)
+where
+	T: revision::SerializeRevisioned
+		+ revision::DeserializeRevisioned
+		+ revision::SkipRevisioned
+		+ Clone
+		+ std::fmt::Debug
+		+ Eq,
+{
+	let mut bytes = Vec::new();
+	serialize_indexed_seq(&items, &mut bytes).unwrap();
+
+	let mut r: &[u8] = &bytes;
+	skip_indexed_seq::<T, _>(&mut r).unwrap();
+	assert!(r.is_empty(), "skip_indexed_seq left {} bytes ({} elements)", r.len(), items.len(),);
+
+	let mut r: &[u8] = &bytes;
+	let decoded: Vec<T> = deserialize_indexed_seq(&mut r).unwrap();
+	assert!(r.is_empty(), "deserialize_indexed_seq left bytes");
+	assert_eq!(decoded, items);
+}
+
+// -----------------------------------------------------------------------------
+// Map
+// -----------------------------------------------------------------------------
+
+#[test]
+fn skip_indexed_map_legacy_body_string_to_u64() {
+	// 3 entries < OFFSET_TABLE_MIN_LEN(=8) → legacy `(K,V)*` shape.
+	let mut m = BTreeMap::new();
+	m.insert("alpha".to_string(), 1u64);
+	m.insert("bravo".to_string(), 2u64);
+	m.insert("charlie".to_string(), 3u64);
+	round_trip_map(m);
+}
+
+#[test]
+fn skip_indexed_map_indexed_body_fixed_keys_fixed_values() {
+	// 16 entries ≥ threshold → indexed shape (offset table + region lengths).
+	let mut m = BTreeMap::new();
+	for i in 0u32..16 {
+		m.insert(i, (i as i64) * -7 + 1);
+	}
+	round_trip_map(m);
+}
+
+#[test]
+fn skip_indexed_map_indexed_body_variable_length_keys_and_values() {
+	// Indexed body with String keys and String values of varying lengths
+	// — exercises the dense-region-length path against multi-byte varints in
+	// the entry payloads.
+	let mut m = BTreeMap::new();
+	for i in 0..12 {
+		let key = format!("k{}-{}", i, "x".repeat(i));
+		let val = format!("v{}-{}", i, "y".repeat(i * 2));
+		m.insert(key, val);
+	}
+	round_trip_map(m);
+}
+
+#[test]
+fn skip_indexed_map_empty() {
+	let m: BTreeMap<String, u32> = BTreeMap::new();
+	round_trip_map(m);
+}
+
+#[test]
+fn skip_indexed_map_just_above_threshold() {
+	// At exactly OFFSET_TABLE_MIN_LEN the indexed path engages; check the
+	// boundary explicitly.
+	let mut m = BTreeMap::new();
+	for i in 0u32..8 {
+		m.insert(format!("key-{i:02}"), i);
+	}
+	round_trip_map(m);
+}
+
+#[test]
+fn skip_indexed_map_just_below_threshold() {
+	// 7 < OFFSET_TABLE_MIN_LEN: legacy body.
+	let mut m = BTreeMap::new();
+	for i in 0u32..7 {
+		m.insert(format!("key-{i:02}"), i);
+	}
+	round_trip_map(m);
+}
+
+// -----------------------------------------------------------------------------
+// Seq
+// -----------------------------------------------------------------------------
+
+#[test]
+fn skip_indexed_seq_legacy_body() {
+	// 3 < threshold → legacy shape.
+	round_trip_seq::<u32>(vec![10, 20, 30]);
+}
+
+#[test]
+fn skip_indexed_seq_indexed_body_primitives() {
+	let v: Vec<u64> = (0u64..32).map(|i| i * 0xDEAD_BEEF).collect();
+	round_trip_seq(v);
+}
+
+#[test]
+fn skip_indexed_seq_indexed_body_variable_length_elements() {
+	// String elements of varying lengths — exercises the "skip the last
+	// element via T::skip_revisioned" branch with a non-trivial element body.
+	let v: Vec<String> =
+		(0..16).map(|i| format!("element-{i}-{}", "padding".repeat(i % 4))).collect();
+	round_trip_seq(v);
+}
+
+#[test]
+fn skip_indexed_seq_at_threshold() {
+	let v: Vec<u32> = (0u32..8).collect();
+	round_trip_seq(v);
+}
+
+#[test]
+fn skip_indexed_seq_just_below_threshold() {
+	let v: Vec<u32> = (0u32..7).collect();
+	round_trip_seq(v);
+}
+
+#[test]
+fn skip_indexed_seq_empty() {
+	let v: Vec<u32> = Vec::new();
+	round_trip_seq(v);
+}
+
+// -----------------------------------------------------------------------------
+// Set (shares wire format with seq)
+// -----------------------------------------------------------------------------
+
+#[test]
+fn skip_indexed_set_indexed_body_primitives() {
+	let s: BTreeSet<i64> = (0i64..24).map(|i| i * 13 - 7).collect();
+	let mut bytes = Vec::new();
+	serialize_indexed_set_iter(s.iter(), &mut bytes).unwrap();
+
+	let mut r: &[u8] = &bytes;
+	skip_indexed_set::<i64, _>(&mut r).unwrap();
+	assert!(r.is_empty(), "skip_indexed_set left {} bytes", r.len());
+
+	let mut r: &[u8] = &bytes;
+	let decoded: BTreeSet<i64> = deserialize_indexed_set(&mut r).unwrap();
+	assert!(r.is_empty());
+	assert_eq!(decoded, s);
+}
+
+#[test]
+fn skip_indexed_set_below_threshold() {
+	let s: BTreeSet<i64> = (0i64..4).collect();
+	let mut bytes = Vec::new();
+	serialize_indexed_set_iter(s.iter(), &mut bytes).unwrap();
+
+	let mut r: &[u8] = &bytes;
+	skip_indexed_set::<i64, _>(&mut r).unwrap();
+	assert!(r.is_empty());
+}
+
+// -----------------------------------------------------------------------------
+// Sibling-field framing
+// -----------------------------------------------------------------------------
+
+/// `skip_indexed_*` must consume *exactly* the indexed payload — neither
+/// peeking into the following bytes nor leaving any trailing dense bytes
+/// untouched. We verify by following the skip with a sibling read.
+#[test]
+fn skip_indexed_map_leaves_sibling_bytes_intact() {
+	let mut m = BTreeMap::new();
+	for i in 0u32..12 {
+		m.insert(format!("k-{i:03}"), i as i64 * 17);
+	}
+	let mut bytes = Vec::new();
+	serialize_indexed_map(&m, &mut bytes).unwrap();
+	// Append a trailing "sibling" payload — a literal `u32_le` sentinel.
+	let sentinel: u32 = 0xCAFE_BABE;
+	bytes.extend_from_slice(&sentinel.to_le_bytes());
+
+	let mut r: &[u8] = &bytes;
+	skip_indexed_map::<String, i64, _>(&mut r).unwrap();
+	assert_eq!(r.len(), 4, "skip should leave exactly 4 trailing bytes");
+	assert_eq!(u32::from_le_bytes(r.try_into().unwrap()), sentinel);
+}
+
+#[test]
+fn skip_indexed_seq_leaves_sibling_bytes_intact() {
+	let v: Vec<String> = (0..16).map(|i| format!("seq-{i:02}-{}", "p".repeat(i))).collect();
+	let mut bytes = Vec::new();
+	serialize_indexed_seq(&v, &mut bytes).unwrap();
+	let sentinel: u32 = 0x1234_5678;
+	bytes.extend_from_slice(&sentinel.to_le_bytes());
+
+	let mut r: &[u8] = &bytes;
+	skip_indexed_seq::<String, _>(&mut r).unwrap();
+	assert_eq!(r.len(), 4, "skip should leave exactly 4 trailing bytes");
+	assert_eq!(u32::from_le_bytes(r.try_into().unwrap()), sentinel);
+}
+
+// -----------------------------------------------------------------------------
+// Cross-check: skip via trait method matches skip via free function
+// -----------------------------------------------------------------------------
+
+#[test]
+fn skip_indexed_map_via_trait_method_matches_free_function() {
+	let mut m = BTreeMap::new();
+	for i in 0u32..10 {
+		m.insert(format!("kkk-{i}"), i as u64);
+	}
+	let mut bytes = Vec::new();
+	<BTreeMap<String, u64> as IndexedMapEncoded>::serialize_indexed_map(&m, &mut bytes).unwrap();
+
+	let mut r_free: &[u8] = &bytes;
+	skip_indexed_map::<String, u64, _>(&mut r_free).unwrap();
+	let consumed_free = bytes.len() - r_free.len();
+
+	let mut r_trait: &[u8] = &bytes;
+	<BTreeMap<String, u64> as IndexedMapEncoded>::skip_indexed_map(&mut r_trait).unwrap();
+	let consumed_trait = bytes.len() - r_trait.len();
+
+	assert_eq!(consumed_free, consumed_trait);
+	assert_eq!(consumed_free, bytes.len());
+}
+
+#[test]
+fn skip_indexed_seq_via_trait_method_matches_free_function() {
+	let v: Vec<i32> = (0i32..16).map(|i| i * -5).collect();
+	let mut bytes = Vec::new();
+	<Vec<i32> as IndexedSeqEncoded>::serialize_indexed_seq(&v, &mut bytes).unwrap();
+
+	let mut r_free: &[u8] = &bytes;
+	skip_indexed_seq::<i32, _>(&mut r_free).unwrap();
+	let consumed_free = bytes.len() - r_free.len();
+
+	let mut r_trait: &[u8] = &bytes;
+	<Vec<i32> as IndexedSeqEncoded>::skip_indexed_seq(&mut r_trait).unwrap();
+	let consumed_trait = bytes.len() - r_trait.len();
+
+	assert_eq!(consumed_free, consumed_trait);
+	assert_eq!(consumed_free, bytes.len());
+}
+
+#[test]
+fn skip_indexed_set_via_trait_method_matches_free_function() {
+	let s: BTreeSet<String> = (0..10).map(|i| format!("set-{i:02}")).collect();
+	let mut bytes = Vec::new();
+	<BTreeSet<String> as IndexedSetEncoded>::serialize_indexed_set(&s, &mut bytes).unwrap();
+
+	let mut r_free: &[u8] = &bytes;
+	skip_indexed_set::<String, _>(&mut r_free).unwrap();
+	let consumed_free = bytes.len() - r_free.len();
+
+	let mut r_trait: &[u8] = &bytes;
+	<BTreeSet<String> as IndexedSetEncoded>::skip_indexed_set(&mut r_trait).unwrap();
+	let consumed_trait = bytes.len() - r_trait.len();
+
+	assert_eq!(consumed_free, consumed_trait);
+	assert_eq!(consumed_free, bytes.len());
+}


### PR DESCRIPTION
## Summary

Cuts the per-record cost of skipping `#[revision(indexed_map)]` /
`#[revision(indexed_seq)]` / `#[revision(indexed_set)]` fields. Driven
by a SurrealDB no-index scan profile where the macro-emitted
`skip_indexed_*` call inside the byte-level pre-decode filter took
~15 % of total CPU on its own — per record, the old skip walked every
K/V via `SkipRevisioned::skip_revisioned` and allocated a
`vec![0u8; len * 8 + 8]` discard buffer just to step past the offset
table. `mi_page_malloc_zero` showed up at ~9 % from that allocation.

The indexed-map wire prologue already records both dense regions'
total byte lengths (`keys_region_len` and `vals_region_len` as
`u32_le`), so skipping reduces to byte arithmetic + a pointer-bump on
slice-backed readers — no copy, no allocation, no per-entry skip.

## Changes

- **`IndexedMapEncoded::skip_indexed_map`** is now O(1) on indexed
  bodies: read the two `u32_le` region lengths from the prologue,
  `BorrowedReader::advance` past the offset table and dense regions.
  `K::skip_revisioned` and `V::skip_revisioned` are never invoked.
  Legacy (sub-threshold) bodies still walk entries because they carry
  no offset table.
- **`IndexedSeqEncoded::skip_indexed_seq`** reduces from O(N) to a
  single entry skip: the seq prologue records per-element offsets but
  not the total dense length, so the new path reads the last offset,
  advances to the start of the final element, then calls
  `T::skip_revisioned` once. `skip_indexed_set` delegates to seq and
  inherits the fix.
- **Trait method readers tighten to `BorrowedReader`**: the bound
  changes from `R: Read` to `R: BorrowedReader` on the three
  `skip_indexed_*` trait methods so `advance(n)` (zero-copy on
  slice-backed readers) is available. This is the only breaking change.
- **Blanket `BorrowedReader for &mut R where R: BorrowedReader`** so
  the macro-emitted walker code can call through the tightened-bound
  methods without an explicit reborrow. The walker holds
  `reader: &'r mut R` and matches with `&mut self.repr`, producing a
  `&mut &'r mut R` binding; the forwarding impl bridges this directly.

## Wire format

Unchanged. Bytes produced by 0.25.x deserialise identically with
0.26.0, and vice versa. This is a parser-side fast path only.

## Breaking change (source-level only)

Hand-written `IndexedMapEncoded` / `IndexedSeqEncoded` /
`IndexedSetEncoded` impls outside this crate (e.g. SurrealDB's
`VecMap` / `VecSet`) need a one-line bound update on the
`skip_indexed_*` method:

```rust
// before
fn skip_indexed_map<R: std::io::Read>(r: &mut R) -> Result<(), Error> { ... }
// after
fn skip_indexed_map<R: BorrowedReader>(r: &mut R) -> Result<(), Error> { ... }
```

Everything that flows through the `#[revisioned]` macro already uses
`BorrowedReader`-bounded readers (`WalkRevisioned::Walker<'r, R: BorrowedReader>`),
so consumer call sites built on the macro need no changes.

Version bumped to **0.26.0**.

## Test plan

- [x] `cargo test --all-features` — 397+ tests pass including 19 new
      ones in `tests/skip_indexed_fast_path.rs` covering: legacy /
      indexed shapes, threshold boundaries (7, 8, 16), fixed-width and
      variable-length K/V, sibling-byte framing, and a trait-vs-free-
      function consistency cross-check.
- [x] `cargo clippy --all-features --tests --benches -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] `cargo bench --bench skip_surrealdb_doc -- --quick` runs cleanly
      (proper performance comparison happens in the downstream surrealdb
      PR that picks up this version bump).