### PR TITLE
perf(indexed): drop discard-buffer alloc from deserialize path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased — alloc-free indexed deserialize
+
+Removes the per-call heap allocation from the indexed-body **deserialize** path, completing the work [#67](https://github.com/surrealdb/revision/pull/67) started for the **skip** path. The wire format and all public signatures are unchanged.
+
+### Performance
+
+- **`deserialize_indexed_map` / `deserialize_indexed_seq` (and the `HashMap` `IndexedMapEncoded` impl) no longer allocate a `vec![0u8; n]` discard buffer** to step over the offset-table prologue. They now use `slice_reader::advance_read`, the same fixed 4 KB stack-buffer read loop the other `SkipRevisioned` impls use — one fewer heap allocation per indexed map/seq decoded, no behavioural change. The reader bound stays `R: Read` (unlike the `skip_indexed_*` fast path, sequential decode can't pointer-bump), so this is not a breaking change.
+
 ## Unreleased — O(1) skip for indexed bodies
 
 Fast-path the per-record cost of skipping `#[revision(indexed_map)]` /

--- a/src/optimised/indexed/serialize.rs
+++ b/src/optimised/indexed/serialize.rs
@@ -17,7 +17,7 @@ use crate::Error;
 use crate::SkipRevisioned;
 use crate::optimised::indexed::OFFSET_TABLE_MIN_LEN;
 use crate::optimised::indexed::seq_walk::FLAG_INDEXED;
-use crate::slice_reader::BorrowedReader;
+use crate::slice_reader::{BorrowedReader, advance_read};
 use crate::{DeserializeRevisioned, SerializeRevisioned};
 
 // -----------------------------------------------------------------------------
@@ -138,8 +138,7 @@ where
 		}
 		// Skip the offset tables + region lengths.
 		let table_bytes = len.checked_mul(8).ok_or(Error::OptimisedSubReaderOverrun)?;
-		let mut discard = vec![0u8; table_bytes + 8];
-		r.read_exact(&mut discard).map_err(Error::Io)?;
+		advance_read(r, table_bytes + 8)?;
 		let mut keys: Vec<K> = Vec::with_capacity(len);
 		for _ in 0..len {
 			keys.push(K::deserialize_revisioned(r)?);
@@ -749,8 +748,7 @@ where
 	// Skip the offset table (len * 8) and region-length pair (8 bytes); we
 	// don't need them for sequential decode.
 	let table_bytes = len.checked_mul(8).ok_or(Error::OptimisedSubReaderOverrun)?;
-	let mut discard = vec![0u8; table_bytes + 8];
-	reader.read_exact(&mut discard).map_err(Error::Io)?;
+	advance_read(reader, table_bytes + 8)?;
 
 	// Dense keys (sorted ascending) come first, then dense values in matching
 	// order. Each K and V know their own wire length via DeserializeRevisioned.
@@ -794,8 +792,7 @@ where
 
 	// Skip the offset table (len * 4 bytes).
 	let table_bytes = len.checked_mul(4).ok_or(Error::OptimisedSubReaderOverrun)?;
-	let mut discard = vec![0u8; table_bytes];
-	reader.read_exact(&mut discard).map_err(Error::Io)?;
+	advance_read(reader, table_bytes)?;
 
 	let mut out = Vec::with_capacity(len);
 	for _ in 0..len {


### PR DESCRIPTION
## Summary

Removes the per-call heap allocation from the indexed-body **deserialize** path, completing the work [#67](https://github.com/surrealdb/revision/pull/67) did for the **skip** path.

`deserialize_indexed_map`, `deserialize_indexed_seq`, and the `HashMap` `IndexedMapEncoded` impl each allocated a `vec![0u8; n]` discard buffer purely to `read_exact` past the offset-table prologue before reading the dense regions:

```rust
let table_bytes = len.checked_mul(8).ok_or(Error::OptimisedSubReaderOverrun)?;
let mut discard = vec![0u8; table_bytes + 8];
reader.read_exact(&mut discard).map_err(Error::Io)?;
```

These now use `slice_reader::advance_read` — the same fixed 4 KB stack-buffer read loop the other `SkipRevisioned` impls already use — so the prologue is consumed with no heap allocation:

```rust
let table_bytes = len.checked_mul(8).ok_or(Error::OptimisedSubReaderOverrun)?;
advance_read(reader, table_bytes + 8)?;
```

## Not a breaking change

Sequential decode reads the dense regions byte-for-byte, so unlike the `skip_indexed_*` fast path it can't pointer-bump and the reader bound stays `R: Read` (no tightening to `BorrowedReader`). Public signatures and the on-wire format are both unchanged; this is a pure internal allocation removal.

## Test plan

- [x] `cargo test --all-features` — all tests pass (no behavioural change).
- [x] `cargo clippy --all-features --tests -- -D warnings` clean.
- [x] `cargo +nightly fmt --check` clean.