### PR TITLE
perf(indexed): construct lookup bounds errors lazily in find_value_bytes

### DIFF
--- a/src/optimised/indexed/map_walk.rs
+++ b/src/optimised/indexed/map_walk.rs
@@ -274,11 +274,16 @@ impl<'p, K, V> IndexedMapWalker<'p, K, V> {
 			// the `Some` arm. On `from_payload_unvalidated` a corrupt offset
 			// would otherwise panic and abort under `panic = 'abort'`; return
 			// a recoverable error so the caller can fall back to a full decode.
-			let key_bytes =
-				p.keys_region.get(k_start..k_end).ok_or(Error::OptimisedOffsetOutOfRange {
+			// `let .. else` rather than `ok_or`: this runs once per
+			// binary-search probe on scan hot paths, and an eager `ok_or`
+			// argument constructs and drops the error on every successful
+			// probe — `Error`'s size and drop glue make that measurable.
+			let Some(key_bytes) = p.keys_region.get(k_start..k_end) else {
+				return Err(Error::OptimisedOffsetOutOfRange {
 					offset: k_end as u32,
 					payload_len: p.keys_region.len() as u32,
-				})?;
+				});
+			};
 			match predicate(key_bytes) {
 				Ordering::Equal => {
 					let v_start = p.val_off(mid) as usize;
@@ -287,12 +292,13 @@ impl<'p, K, V> IndexedMapWalker<'p, K, V> {
 					} else {
 						p.vals_region.len()
 					};
-					return p.vals_region.get(v_start..v_end).map(Some).ok_or(
-						Error::OptimisedOffsetOutOfRange {
+					let Some(value_bytes) = p.vals_region.get(v_start..v_end) else {
+						return Err(Error::OptimisedOffsetOutOfRange {
 							offset: v_end as u32,
 							payload_len: p.vals_region.len() as u32,
-						},
-					);
+						});
+					};
+					return Ok(Some(value_bytes));
 				}
 				Ordering::Less => lo = mid + 1,
 				Ordering::Greater => hi = mid,


### PR DESCRIPTION
## What

`Option::ok_or` evaluates its argument eagerly, so every binary-search probe in `IndexedMapWalker::find_value_bytes` constructed an `Error::OptimisedOffsetOutOfRange { .. }` on the stack and dropped it again on the successful (`Some`) path. `Error` is 32 bytes with `String`-carrying variants, so the construct + drop glue is real work inside the per-probe loop.

This PR restructures both checked-slice sites (key probe and value slice) to `let .. else`, so the error value is only built on the actual out-of-range branch. `let .. else` rather than `ok_or_else` because clippy's `unnecessary_lazy_evaluations` considers the struct literal cheap enough to suggest converting back to the eager form.

## Why

Profiling SurrealDB's `scans/where_integer_eq_full` language-test bench (a 100k-row full scan whose pre-decode WHERE filter calls `find_value_bytes` once per row, ~4–5 probes each) attributed **2.1% of total scan CPU** (432ms of 20.8s) to `drop_in_place<revision::error::Error>` from this loop — errors that were never used.

## Behavior

No behavior change: the same error with the same fields is returned on the same branch. Covered by the existing `unvalidated_find_value_bytes_errors_instead_of_panicking` test; full suite passes, clippy clean.